### PR TITLE
Fix iOS widget not showing options for selecting timetables

### DIFF
--- a/ios/OTLPlusIntents/IntentHandler.swift
+++ b/ios/OTLPlusIntents/IntentHandler.swift
@@ -81,12 +81,9 @@ class IntentHandler: INExtension, ConfigurationIntentHandling {
         var data: [Timetable]? = try? JSONDecoder().decode([Timetable].self, from: (sharedDefaults?.string(forKey: "widgetData")?.data(using: .utf8)) ?? Data())
         var tables: [NextClassTimetable] = []
         
-        for i in 0..<data!.count {
-            if i == 0 {
-                tables.append(NextClassTimetable(identifier: "\(i)", display: "내 시간표"))
-            } else {
-                tables.append(NextClassTimetable(identifier: "\(i)", display: "내 시간표 \(i)"))
-            }
+        tables.append(NextClassTimetable(identifier: "0", display: "내 시간표"))
+        for i in 1..<data!.count {
+            tables.append(NextClassTimetable(identifier: "\(i)", display: "내 시간표 \(i)"))
         }
         
         let collection = INObjectCollection(items: tables)

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -712,7 +712,7 @@
 				INFOPLIST_FILE = OTLPlusIntents/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OTLPlusIntents;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 The Chromium Authors. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -751,7 +751,7 @@
 				INFOPLIST_FILE = OTLPlusIntents/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OTLPlusIntents;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 The Chromium Authors. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -789,7 +789,7 @@
 				INFOPLIST_FILE = OTLPlusIntents/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OTLPlusIntents;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 The Chromium Authors. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -830,7 +830,7 @@
 				INFOPLIST_FILE = OTLWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "next class widget";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 The Chromium Authors. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -871,7 +871,7 @@
 				INFOPLIST_FILE = OTLWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "next class widget";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 The Chromium Authors. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -911,7 +911,7 @@
 				INFOPLIST_FILE = OTLWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "next class widget";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 The Chromium Authors. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
iOS 홈 화면 위젯에서 위젯 편집을 누르면 나오는 시간표 선택에서
시간표가 뜨지 않는 문제 수정

|위젯 편집|시간표 선택|
|---|---|
|![Simulator Screenshot - iPhone 14 Pro - 2023-06-30 at 03 20 57](https://github.com/sparcs-kaist/otl-app/assets/30364442/1c4f4eb5-84ba-47a0-a62b-534448319df1)|![Simulator Screenshot - iPhone 14 Pro - 2023-06-30 at 03 21 01](https://github.com/sparcs-kaist/otl-app/assets/30364442/0acb7fa4-3ada-4792-b2fb-6b58c611c0ab)|
