### PR TITLE
Fix error during building with Xcode 15 beta

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -312,11 +312,11 @@
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
+				8BB3DE1029D1F25B001AD191 /* Embed Foundation Extensions */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				E81541A619F92FF6837FDEEC /* [CP] Embed Pods Frameworks */,
 				894C64DD28C8F8FC006549F9 /* ShellScript */,
-				8BB3DE1029D1F25B001AD191 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
## 발생한 문제
- Version 15.0 beta 5 (15A5209g)
- 빌드 시 아래 문제 발생
- `DT_TOOLCHAIN_DIR cannot be used to evaluate LIBRARY_SEARCH_PATHS, use TOOLCHAIN_DIR instead`


<img width="385" alt="스크린샷 2023-08-06 오후 9 42 34" src="https://github.com/sparcs-kaist/otl-app/assets/30364442/3e75bb0d-1cb6-4c1b-9c68-23d661e7cf35">

## 해결방법
- iOS Xcode 프로젝트 > Build Phases에서 `Embed Foundation Extensions`의 순서를 바꾼다.