### PR TITLE
Rollback dropdown_button2 to original package

### DIFF
--- a/lib/widgets/dropdown.dart
+++ b/lib/widgets/dropdown.dart
@@ -71,7 +71,6 @@ class Dropdown<T> extends StatelessWidget {
               : null,
         ),
         menuItemStyleData: MenuItemStyleData(
-          height: 42,
           padding: EdgeInsets.zero,
         ),
         items: items.map((itemData) {
@@ -91,8 +90,9 @@ class Dropdown<T> extends StatelessWidget {
               ),
             ),
           ];
-          return DropdownMenuItem<T>(
+          return DropdownItem<T>(
             value: itemData.value,
+            height: 42,
             child: Stack(
               alignment: AlignmentDirectional.bottomStart,
               children: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -140,12 +140,11 @@ packages:
   dropdown_button2:
     dependency: "direct main"
     description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "81499508deb9fea0e54eeee82283e073fb0c96f4"
-      url: "https://github.com/sparcs-kaist/dropdown_button2.git"
-    source: git
-    version: "2.3.7"
+      name: dropdown_button2
+      sha256: a60c69cfe075b3b57cbecf163e629e05a5ac7057b9659494f6b80c1960fc7426
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0-beta.4"
   easy_localization:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,14 +39,11 @@ dependencies:
   open_app_file: ^4.0.2
   flutter_native_splash: ^2.3.2
   mailto: ^2.0.0
+  dropdown_button2: ^3.0.0-beta.4
   # Firebase
   firebase_core: ^2.8.0
   firebase_analytics: ^10.1.6
   firebase_crashlytics: ^3.0.17
-  # Forked
-  dropdown_button2:
-    git:
-      url: https://github.com/sparcs-kaist/dropdown_button2.git
 
 dev_dependencies:
   test: ^1.19.5


### PR DESCRIPTION
- #112
위 PR에서 iOS에서 드롭다운이 안 보이는 버그가 있어 dropdown_button2 패키지를
https://github.com/sparcs-kaist/dropdown_button2/commit/81499508deb9fea0e54eeee82283e073fb0c96f4
위처럼 수정하여 사용했었음
- 그러나 원본 패키지의 최근 버전에서 수정되었음https://github.com/AhmedLSayed9/dropdown_button2/blob/53c66f096b6b10ff70ea6948c3a7d3d2e8851e2d/packages/dropdown_button2/lib/src/dropdown_menu.dart#L125
- 따라서 원본 패키지의 3.0.0-beta.4로 복구