### PR TITLE
Add SingleChildScrollView in People Page

### DIFF
--- a/lib/pages/people_page.dart
+++ b/lib/pages/people_page.dart
@@ -15,21 +15,23 @@ class PeoplePage extends StatelessWidget {
         middle: Text('title.credit'.tr(), style: titleBold),
         body: ColoredBox(
           color: OTLColor.grayF,
-          child: Padding(
-            padding: EdgeInsets.all(16.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                _buildContainer('2023.03 ~'),
-                ..._get202303(),
-                const SizedBox(height: 32.0),
-                _buildContainer('2020.03 ~ 2023.02'),
-                const SizedBox(height: 12.0),
-                Text(
-                  'common.coming'.tr(),
-                  style: bodyRegular.copyWith(color: OTLColor.grayA),
-                ),
-              ],
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  _buildContainer('2023.03 ~'),
+                  ..._get202303(),
+                  const SizedBox(height: 32.0),
+                  _buildContainer('2020.03 ~ 2023.02'),
+                  const SizedBox(height: 12.0),
+                  Text(
+                    'common.coming'.tr(),
+                    style: bodyRegular.copyWith(color: OTLColor.grayA),
+                  ),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## Motivation

- Unit test 중 아래 테스트가 실패함.

```dart
  testWidgets("pump PeoplePage", (WidgetTester tester) async {
    tester.pumpWidget(PeoplePage().material);
  });
```

```
══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞═════════════════════════════════════════════════════════
The following assertion was thrown during layout:
A RenderFlex overflowed by 3.0 pixels on the bottom.

The relevant error-causing widget was:
  Column Column:file:///Users/sboh/Repos/otl-app/lib/pages/people_page.dart:20:20

The overflowing RenderFlex has an orientation of Axis.vertical.
The edge of the RenderFlex that is overflowing has been marked in the rendering with a yellow and
black striped pattern. This is usually caused by the contents being too big for the RenderFlex.
Consider applying a flex factor (e.g. using an Expanded widget) to force the children of the
RenderFlex to fit within the available space instead of being sized to their natural size.
This is considered an error condition because it indicates that there is content that cannot be
seen. If the content is legitimately bigger than the available space, consider clipping it with a
ClipRect widget before putting it in the flex, or using a scrollable container rather than a Flex,
like a ListView.
The specific RenderFlex in question is: RenderFlex#017df OVERFLOWING:
  creator: Column ← Padding ← ColoredBox ← Positioned ← Stack ← OTLLayout ←
    KeyedSubtree-[GlobalKey#04eea] ← _BodyBuilder ← MediaQuery ← LayoutId-[<_ScaffoldSlot.body>] ←
    CustomMultiChildLayout ← _ActionsScope ← ⋯
  parentData: offset=Offset(16.0, 16.0) (can use size)
  constraints: BoxConstraints(w=768.0, h=507.0)
  size: Size(768.0, 507.0)
  direction: vertical
  mainAxisAlignment: start
  mainAxisSize: max
  crossAxisAlignment: center
  verticalDirection: down
◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤
════════════════════════════════════════════════════════════════════════════════════════════════════
```

## Description

- "만든 사람들" 페이지에 스크롤뷰를 추가하여 높이가 작은 스크린에 대응하도록 하였습니다.

<img width="559" alt="스크린샷 2024-03-29 오후 6 23 52" src="https://github.com/sparcs-kaist/otl-app/assets/30364442/afa1d28f-088d-4bf8-9a99-4c7a63e029cf">
