### PR TITLE
Resolve #192, show more info in timetable block

### DIFF
--- a/lib/widgets/timetable_block.dart
+++ b/lib/widgets/timetable_block.dart
@@ -51,7 +51,7 @@ class TimetableBlock extends StatelessWidget {
           color: isTemp ? OTLColor.grayF : OTLColor.gray0,
           overflow: TextOverflow.ellipsis,
         ),
-        maxLines: maxLines > 1 ? maxLines : 1,
+        maxLines: 2,
       ));
     }
 
@@ -70,6 +70,7 @@ class TimetableBlock extends StatelessWidget {
             style: labelRegular.copyWith(
               color: isTemp ? OTLColor.grayE : OTLColor.gray6,
               overflow: TextOverflow.ellipsis,
+              fontSize: 10,
             ),
             maxLines: maxLines > 1 ? maxLines : 1,
           ),


### PR DESCRIPTION
## Description

Timetable block의 title label maxLine을 2로 조정하였습니다. location label fontSize를 줄였습니다.

## Screenshot

![CleanShot 2024-09-12 at 13 53 06@2x](https://github.com/user-attachments/assets/7ccbe4a4-8171-4132-b718-53c16bff8b87)

