### PR TITLE
Resolve #199, Fix iOS widget not working and add support tinted widget

### DIFF
--- a/ios/OTLWidgets/TodayClassesWidget.swift
+++ b/ios/OTLWidgets/TodayClassesWidget.swift
@@ -191,6 +191,7 @@ struct TodayClassesLectureView: View {
                     Text(lecturePlace)
                         .font(.custom("NotoSansKR-Regular", size: 12))
                         .foregroundColor(Color(red: 102.0/255, green: 102.0/255, blue: 102.0/255))
+                        .widgetAccentable()
                     Spacer()
                 }.padding(.vertical, 8)
                 Spacer()

--- a/ios/OTLWidgets/TodayClassesWidget.swift
+++ b/ios/OTLWidgets/TodayClassesWidget.swift
@@ -10,7 +10,8 @@ import WidgetKit
 import SwiftUI
 import Intents
 
-struct TodayClassesWidgetData: Hashable {
+struct TodayClassesWidgetData: Identifiable {
+    let id = UUID()
     let title: String
     let place: String
     let width: Double
@@ -30,8 +31,32 @@ struct TodayClassesWidgetEntryView : View {
     }
 
     var body: some View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            TodayClassesWidgetView(background: false, entry: entry)
+                .containerBackground(for: .widget) {
+                    widgetBackground
+                }
+        } else {
+            TodayClassesWidgetView(background: true, entry: entry)
+        }
+    }
+}
+
+struct TodayClassesWidgetView: View {
+    @Environment(\.colorScheme) var colorScheme
+    @State var background: Bool = false
+    
+    var entry: Provider.Entry
+    
+    var widgetBackground: some View {
+        colorScheme == .dark ? Color(red: 51.0/255, green: 51.0/255, blue: 51.0/255) : Color(red: 249.0/255, green: 240.0/255, blue: 240.0/255)
+    }
+    
+    var body: some View {
         ZStack {
-            widgetBackground
+            if background {
+                widgetBackground
+            }
             Color.clear
                 .overlay(
                     Group {
@@ -63,15 +88,13 @@ struct TodayClassesWidgetEntryView : View {
                                 }
                             }
                             if (entry.timetableData != nil) {
-                                ForEach(getLecturesData(data: getLecturesForDay(timetable: entry.timetableData?[Int(entry.configuration.nextClassTimetable?.identifier ?? "0") ?? 0], day: getDayWithWeekDay(weekday: Calendar.current.component(.weekday, from: entry.date)))), id: \.self) { data in
+                                ForEach(getLecturesData(data: getLecturesForDay(timetable: entry.timetableData?[Int(entry.configuration.nextClassTimetable?.identifier ?? "0") ?? 0], day: getDayWithWeekDay(weekday: Calendar.current.component(.weekday, from: entry.date))))) { data in
                                     VStack {
-                                        Spacer()
-                                            .frame(height: 24)
+                                        Spacer().frame(height: 24)
                                         TodayClassesLectureView(lectureName: data.title, lecturePlace: data.place, colour: data.colour)
                                             .frame(width: data.width)
                                             .offset(x: data.x)
-                                        Spacer()
-                                            .frame(height: 2)
+                                        Spacer().frame(height: 2)
                                     }
                                 }
                             }
@@ -148,6 +171,8 @@ struct TodayClassesWidgetEntryView : View {
 }
 
 struct TodayClassesLectureView: View {
+    @Environment(\.widgetRenderingMode) var renderingMode
+    
     let lectureName: String
     let lecturePlace: String
     let colour: Color
@@ -156,6 +181,8 @@ struct TodayClassesLectureView: View {
         ZStack {
             RoundedRectangle(cornerRadius: 2)
                 .foregroundColor(colour)
+                .widgetAccentable()
+                .opacity(renderingMode == .accented ? 0.2 : 1.0)
             HStack {
                 VStack(alignment: .leading) {
                     Text(lectureName)
@@ -182,7 +209,7 @@ struct ExactTimeLine: View {
             Rectangle()
                 .fill(Color(red: 229.0/255, green: 76.0/255, blue: 99.0/255))
                 .frame(width: 2)
-        }
+        }.widgetAccentable()
     }
 }
 

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -48,8 +48,20 @@ class _MainPageState extends State<MainPage> {
       final cookieManager = WebviewCookieManager();
       final cookies = await cookieManager.getCookies('https://otl.sparcs.org');
       for (var cookie in cookies) {
-        if (cookie.name == 'sessionid') {
-          WidgetKit.setItem('sessionid', cookie.value, 'group.org.sparcs.otl');
+        if (cookie.name == 'refreshToken') {
+          WidgetKit.setItem(
+              'refreshToken', cookie.value, 'group.org.sparcs.otl');
+          WidgetKit.reloadAllTimelines();
+        }
+
+        if (cookie.name == 'csrftoken') {
+          WidgetKit.setItem('csrftoken', cookie.value, 'group.org.sparcs.otl');
+          WidgetKit.reloadAllTimelines();
+        }
+
+        if (cookie.name == 'accessToken') {
+          WidgetKit.setItem(
+              'accessToken', cookie.value, 'group.org.sparcs.otl');
           WidgetKit.reloadAllTimelines();
         }
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1017,10 +1017,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description

- Backend migration 이후 iOS widget이 작동하지 않는 오류를 수정합니다.
  - sessionid -> token 로직 변경으로 인해 로그인이 진행되지 않았습니다.
  - api/semesters에서 넘겨주는 date string format이 변경되었습니다.
- 코드 최적화를 진행하였습니다.
- 하는김에 여러가지 신기능을 추가하였습니다.
  - iOS 17 부터 지원하는 containerBackground 지원을 추가하였습니다. (macOS, iPadOS 에서 .vibrant인 상황에서 정상적으로 표시됩니다.)
  - iOS 18 부터 지원하는 tinted customisation 지원을 추가하였습니다.
- GitHub Actions Xcode 버전을 Xcode_16으로 올렸습니다.

## Screenshots

<img width="320" src="https://github.com/user-attachments/assets/b7e5a5a4-0734-4305-a6ea-73c55d2cac50">

