### PR TITLE
feat: FCM notification topic subscription and settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 env:
   FLUTTER_VERSION: "3.32.x"
   JAVA_VERSION: "17"
-  XCODE_VERSION: "Xcode_16.2"
+  XCODE_VERSION: "Xcode_16.4"
 
 jobs:
   build-android:
@@ -50,9 +50,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Select Xcode version
         run: sudo xcode-select -s '/Applications/${{ env.XCODE_VERSION }}.app/Contents/Developer'
-      - name: Install iOS 18.2 Simulator Runtime
+      - name: Verify iOS SDK
         run: |
-          xcodebuild -downloadPlatform iOS || true
+          xcodebuild -showsdks 2>/dev/null | grep -i iphoneos || true
+          xcrun --sdk iphoneos --show-sdk-path
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -175,7 +175,18 @@
     "throw_test_desc": "for testing firebase crashlytics",
     "about": "About",
     "view_licenses": "View Licenses",
-    "show_channel_talk_button": "Show Channel Talk Button"
+    "show_channel_talk_button": "Show Channel Talk Button",
+    "notification": {
+      "receive": "Receive notifications",
+      "receive_desc": "Receive notifications about various topics.",
+      "promotion": "Promotional notifications",
+      "information": "Informational notifications",
+      "subject_suggestion": "Course suggestion notifications",
+      "consent_title": "Notification consent",
+      "consent_desc": "Would you like to receive helpful notifications from OTL Plus, such as course suggestions and announcements?",
+      "accept": "Accept",
+      "decline": "Later"
+    }
   },
   "department": {
     "department": "Dept.",

--- a/assets/translations/ko.json
+++ b/assets/translations/ko.json
@@ -175,7 +175,18 @@
     "throw_test_desc": "Firebase crashlytics 테스트용",
     "about": "정보",
     "view_licenses": "라이선스 보기",
-    "show_channel_talk_button": "채널톡 버튼 표시하기"
+    "show_channel_talk_button": "채널톡 버튼 표시하기",
+    "notification": {
+      "receive": "알림 받기",
+      "receive_desc": "다양한 주제에 대한 알림을 수신합니다.",
+      "promotion": "광고성 알림 수신",
+      "information": "정보성 알림 수신",
+      "subject_suggestion": "과목 제안 알림 수신",
+      "consent_title": "알림 수신 동의",
+      "consent_desc": "OTL Plus에서 과목 제안, 공지사항 등 유용한 정보를 알림으로 받아보시겠습니까?",
+      "accept": "동의",
+      "decline": "나중에"
+    }
   },
   "department": {
     "department": "학과",

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:otlplus/providers/settings_model.dart';
+import 'package:otlplus/utils/navigator.dart';
+import 'package:otlplus/widgets/otl_dialog.dart';
 import 'package:otlplus/widgets/otl_scaffold.dart';
 import 'package:otlplus/pages/dictionary_page.dart';
 import 'package:otlplus/pages/main_page.dart';
 import 'package:otlplus/pages/review_page.dart';
 import 'package:otlplus/pages/timetable_page.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class OTLHome extends StatefulWidget {
   static String route = 'home';
@@ -29,18 +34,25 @@ class _OTLHomeState extends State<OTLHome> with SingleTickerProviderStateMixin {
       vsync: this,
     );
 
-    // WidgetsBinding.instance.addPostFrameCallback(
-    //   (_) async {
-    //     if ((await SharedPreferences.getInstance())
-    //             .getBool('popup_recruiting_23f') ??
-    //         true) {
-    //       await OTLNavigator.pushDialog(
-    //         context: context,
-    //         builder: (context) => PopUp(),
-    //       );
-    //     }
-    //   },
-    // );
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final prefs = await SharedPreferences.getInstance();
+      if (prefs.getBool('notification_consent_shown') != true) {
+        await OTLNavigator.pushDialog(
+          context: context,
+          builder: (_) => OTLDialog(
+            type: OTLDialogType.notificationConsent,
+            onTapPos: () {
+              context.read<SettingsModel>().setSendAlarm(true);
+              prefs.setBool('notification_consent_shown', true);
+            },
+            onTapNeg: () {
+              context.read<SettingsModel>().setSendAlarm(false);
+              prefs.setBool('notification_consent_shown', true);
+            },
+          ),
+        );
+      }
+    });
   }
 
   @override

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -36,16 +36,14 @@ class SettingsPage extends StatelessWidget {
                       Dropdown<bool>(
                         customButton: Container(
                           height: 34,
-                          padding:
-                              const EdgeInsets.symmetric(horizontal: 16),
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
                           decoration: BoxDecoration(
                             color: OTLColor.pinksLight,
                             borderRadius: BorderRadius.circular(20),
                           ),
                           child: Row(
                             children: [
-                              Icon(Icons.language,
-                                  color: OTLColor.pinksMain),
+                              Icon(Icons.language, color: OTLColor.pinksMain),
                               const SizedBox(width: 8),
                               Text(
                                 isEn
@@ -75,11 +73,13 @@ class SettingsPage extends StatelessWidget {
                         offsetY: -6,
                         onChanged: (value) {
                           if (value!) {
-                            EasyLocalization.of(context)
-                                ?.setLocale(Locale('en'));
+                            EasyLocalization.of(
+                              context,
+                            )?.setLocale(Locale('en'));
                           } else {
-                            EasyLocalization.of(context)
-                                ?.setLocale(Locale('ko'));
+                            EasyLocalization.of(
+                              context,
+                            )?.setLocale(Locale('ko'));
                           }
                         },
                       ),
@@ -89,19 +89,15 @@ class SettingsPage extends StatelessWidget {
                     title: "settings.notification.receive".tr(),
                     subtitle: "settings.notification.receive_desc".tr(),
                     trailing: CupertinoSwitch(
-                      value:
-                          context.watch<SettingsModel>().getSendAlarm(),
-                      onChanged: (value) => context
-                          .read<SettingsModel>()
-                          .setSendAlarm(value),
+                      value: context.watch<SettingsModel>().getSendAlarm(),
+                      onChanged: (value) =>
+                          context.read<SettingsModel>().setSendAlarm(value),
                     ),
                   ),
                   Visibility(
-                    visible:
-                        context.watch<SettingsModel>().getSendAlarm(),
+                    visible: context.watch<SettingsModel>().getSendAlarm(),
                     child: _buildListTile(
-                      title: "settings.notification.subject_suggestion"
-                          .tr(),
+                      title: "settings.notification.subject_suggestion".tr(),
                       trailing: CupertinoSwitch(
                         value: context
                             .watch<SettingsModel>()
@@ -113,8 +109,7 @@ class SettingsPage extends StatelessWidget {
                     ),
                   ),
                   Visibility(
-                    visible:
-                        context.watch<SettingsModel>().getSendAlarm(),
+                    visible: context.watch<SettingsModel>().getSendAlarm(),
                     child: _buildListTile(
                       title: "settings.notification.promotion".tr(),
                       trailing: CupertinoSwitch(
@@ -128,8 +123,7 @@ class SettingsPage extends StatelessWidget {
                     ),
                   ),
                   Visibility(
-                    visible:
-                        context.watch<SettingsModel>().getSendAlarm(),
+                    visible: context.watch<SettingsModel>().getSendAlarm(),
                     child: _buildListTile(
                       title: "settings.notification.information".tr(),
                       trailing: CupertinoSwitch(
@@ -178,9 +172,9 @@ class SettingsPage extends StatelessWidget {
                           .watch<SettingsModel>()
                           .getShowsChannelTalkButton(),
                       onChanged: (value) {
-                        context
-                            .read<SettingsModel>()
-                            .setShowsChannelTalkButton(value);
+                        context.read<SettingsModel>().setShowsChannelTalkButton(
+                          value,
+                        );
 
                         if (!value) {
                           ChannelTalk.hideChannelButton();
@@ -205,9 +199,8 @@ class SettingsPage extends StatelessWidget {
                         context: context,
                         builder: (_) => OTLDialog(
                           type: OTLDialogType.resetSettings,
-                          onTapPos: () => context
-                              .read<SettingsModel>()
-                              .clearAllValues(),
+                          onTapPos: () =>
+                              context.read<SettingsModel>().clearAllValues(),
                         ),
                       );
                     },

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -26,7 +26,8 @@ class SettingsPage extends StatelessWidget {
           color: OTLColor.grayF,
           child: Padding(
             padding: const EdgeInsets.all(16.0),
-            child: Column(
+            child: SingleChildScrollView(
+              child: Column(
               children: [
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -79,6 +80,56 @@ class SettingsPage extends StatelessWidget {
                       },
                     ),
                   ],
+                ),
+                _buildListTile(
+                  title: "settings.notification.receive".tr(),
+                  subtitle: "settings.notification.receive_desc".tr(),
+                  trailing: CupertinoSwitch(
+                    value: context.watch<SettingsModel>().getSendAlarm(),
+                    onChanged: (value) =>
+                        context.read<SettingsModel>().setSendAlarm(value),
+                  ),
+                ),
+                Visibility(
+                  visible: context.watch<SettingsModel>().getSendAlarm(),
+                  child: _buildListTile(
+                    title: "settings.notification.subject_suggestion".tr(),
+                    trailing: CupertinoSwitch(
+                      value: context
+                          .watch<SettingsModel>()
+                          .getSubjectSuggestionAlarm(),
+                      onChanged: (value) => context
+                          .read<SettingsModel>()
+                          .setSubjectSuggestionAlarm(value),
+                    ),
+                  ),
+                ),
+                Visibility(
+                  visible: context.watch<SettingsModel>().getSendAlarm(),
+                  child: _buildListTile(
+                    title: "settings.notification.promotion".tr(),
+                    trailing: CupertinoSwitch(
+                      value:
+                          context.watch<SettingsModel>().getPromotionAlarm(),
+                      onChanged: (value) => context
+                          .read<SettingsModel>()
+                          .setPromotionAlarm(value),
+                    ),
+                  ),
+                ),
+                Visibility(
+                  visible: context.watch<SettingsModel>().getSendAlarm(),
+                  child: _buildListTile(
+                    title: "settings.notification.information".tr(),
+                    trailing: CupertinoSwitch(
+                      value: context
+                          .watch<SettingsModel>()
+                          .getInformationAlarm(),
+                      onChanged: (value) => context
+                          .read<SettingsModel>()
+                          .setInformationAlarm(value),
+                    ),
+                  ),
                 ),
                 _buildListTile(
                   title: "settings.send_error_log".tr(),
@@ -164,6 +215,7 @@ class SettingsPage extends StatelessWidget {
                   ),
                 ),
               ],
+              ),
             ),
           ),
         ),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -28,193 +28,210 @@ class SettingsPage extends StatelessWidget {
             padding: const EdgeInsets.all(16.0),
             child: SingleChildScrollView(
               child: Column(
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text("settings.language".tr(), style: bodyBold),
-                    Dropdown<bool>(
-                      customButton: Container(
-                        height: 34,
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        decoration: BoxDecoration(
-                          color: OTLColor.pinksLight,
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: Row(
-                          children: [
-                            Icon(Icons.language, color: OTLColor.pinksMain),
-                            const SizedBox(width: 8),
-                            Text(
-                              isEn
-                                  ? "settings.english".tr()
-                                  : "settings.korean".tr(),
-                              style: bodyBold.copyWith(
-                                height: 1.2,
-                                color: OTLColor.pinksMain,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text("settings.language".tr(), style: bodyBold),
+                      Dropdown<bool>(
+                        customButton: Container(
+                          height: 34,
+                          padding:
+                              const EdgeInsets.symmetric(horizontal: 16),
+                          decoration: BoxDecoration(
+                            color: OTLColor.pinksLight,
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: Row(
+                            children: [
+                              Icon(Icons.language,
+                                  color: OTLColor.pinksMain),
+                              const SizedBox(width: 8),
+                              Text(
+                                isEn
+                                    ? "settings.english".tr()
+                                    : "settings.korean".tr(),
+                                style: bodyBold.copyWith(
+                                  height: 1.2,
+                                  color: OTLColor.pinksMain,
+                                ),
                               ),
-                            ),
-                          ],
+                            ],
+                          ),
                         ),
+                        items: [
+                          ItemData(
+                            value: false,
+                            text: "settings.korean".tr(),
+                            icon: !isEn ? Icons.check : null,
+                          ),
+                          ItemData(
+                            value: true,
+                            text: "settings.english".tr(),
+                            icon: isEn ? Icons.check : null,
+                          ),
+                        ],
+                        isIconLeft: true,
+                        offsetY: -6,
+                        onChanged: (value) {
+                          if (value!) {
+                            EasyLocalization.of(context)
+                                ?.setLocale(Locale('en'));
+                          } else {
+                            EasyLocalization.of(context)
+                                ?.setLocale(Locale('ko'));
+                          }
+                        },
                       ),
-                      items: [
-                        ItemData(
-                          value: false,
-                          text: "settings.korean".tr(),
-                          icon: !isEn ? Icons.check : null,
-                        ),
-                        ItemData(
-                          value: true,
-                          text: "settings.english".tr(),
-                          icon: isEn ? Icons.check : null,
-                        ),
-                      ],
-                      isIconLeft: true,
-                      offsetY: -6,
+                    ],
+                  ),
+                  _buildListTile(
+                    title: "settings.notification.receive".tr(),
+                    subtitle: "settings.notification.receive_desc".tr(),
+                    trailing: CupertinoSwitch(
+                      value:
+                          context.watch<SettingsModel>().getSendAlarm(),
+                      onChanged: (value) => context
+                          .read<SettingsModel>()
+                          .setSendAlarm(value),
+                    ),
+                  ),
+                  Visibility(
+                    visible:
+                        context.watch<SettingsModel>().getSendAlarm(),
+                    child: _buildListTile(
+                      title: "settings.notification.subject_suggestion"
+                          .tr(),
+                      trailing: CupertinoSwitch(
+                        value: context
+                            .watch<SettingsModel>()
+                            .getSubjectSuggestionAlarm(),
+                        onChanged: (value) => context
+                            .read<SettingsModel>()
+                            .setSubjectSuggestionAlarm(value),
+                      ),
+                    ),
+                  ),
+                  Visibility(
+                    visible:
+                        context.watch<SettingsModel>().getSendAlarm(),
+                    child: _buildListTile(
+                      title: "settings.notification.promotion".tr(),
+                      trailing: CupertinoSwitch(
+                        value: context
+                            .watch<SettingsModel>()
+                            .getPromotionAlarm(),
+                        onChanged: (value) => context
+                            .read<SettingsModel>()
+                            .setPromotionAlarm(value),
+                      ),
+                    ),
+                  ),
+                  Visibility(
+                    visible:
+                        context.watch<SettingsModel>().getSendAlarm(),
+                    child: _buildListTile(
+                      title: "settings.notification.information".tr(),
+                      trailing: CupertinoSwitch(
+                        value: context
+                            .watch<SettingsModel>()
+                            .getInformationAlarm(),
+                        onChanged: (value) => context
+                            .read<SettingsModel>()
+                            .setInformationAlarm(value),
+                      ),
+                    ),
+                  ),
+                  _buildListTile(
+                    title: "settings.send_error_log".tr(),
+                    subtitle: "settings.send_error_log_desc".tr(),
+                    trailing: CupertinoSwitch(
+                      value: context
+                          .watch<SettingsModel>()
+                          .getSendCrashlytics(),
+                      onChanged: (value) => context
+                          .read<SettingsModel>()
+                          .setSendCrashlytics(value),
+                    ),
+                  ),
+                  Visibility(
+                    visible: context
+                        .watch<SettingsModel>()
+                        .getSendCrashlytics(),
+                    child: _buildListTile(
+                      title: "settings.send_anonymously".tr(),
+                      subtitle: "settings.send_anonymously_desc".tr(),
+                      trailing: CupertinoSwitch(
+                        value: context
+                            .watch<SettingsModel>()
+                            .getSendCrashlyticsAnonymously(),
+                        onChanged: (value) => context
+                            .read<SettingsModel>()
+                            .setSendCrashlyticsAnonymously(value),
+                      ),
+                    ),
+                  ),
+                  _buildListTile(
+                    title: "settings.show_channel_talk_button".tr(),
+                    trailing: CupertinoSwitch(
+                      value: context
+                          .watch<SettingsModel>()
+                          .getShowsChannelTalkButton(),
                       onChanged: (value) {
-                        if (value!) {
-                          EasyLocalization.of(context)?.setLocale(Locale('en'));
+                        context
+                            .read<SettingsModel>()
+                            .setShowsChannelTalkButton(value);
+
+                        if (!value) {
+                          ChannelTalk.hideChannelButton();
                         } else {
-                          EasyLocalization.of(context)?.setLocale(Locale('ko'));
+                          ChannelTalk.showChannelButton();
                         }
                       },
                     ),
-                  ],
-                ),
-                _buildListTile(
-                  title: "settings.notification.receive".tr(),
-                  subtitle: "settings.notification.receive_desc".tr(),
-                  trailing: CupertinoSwitch(
-                    value: context.watch<SettingsModel>().getSendAlarm(),
-                    onChanged: (value) =>
-                        context.read<SettingsModel>().setSendAlarm(value),
                   ),
-                ),
-                Visibility(
-                  visible: context.watch<SettingsModel>().getSendAlarm(),
-                  child: _buildListTile(
-                    title: "settings.notification.subject_suggestion".tr(),
-                    trailing: CupertinoSwitch(
-                      value: context
-                          .watch<SettingsModel>()
-                          .getSubjectSuggestionAlarm(),
-                      onChanged: (value) => context
-                          .read<SettingsModel>()
-                          .setSubjectSuggestionAlarm(value),
+                  Visibility(
+                    visible: kDebugMode,
+                    child: _buildListTile(
+                      title: "settings.throw_test".tr(),
+                      subtitle: "settings.throw_test_desc".tr(),
+                      onTap: () => throw Exception(),
                     ),
                   ),
-                ),
-                Visibility(
-                  visible: context.watch<SettingsModel>().getSendAlarm(),
-                  child: _buildListTile(
-                    title: "settings.notification.promotion".tr(),
-                    trailing: CupertinoSwitch(
-                      value:
-                          context.watch<SettingsModel>().getPromotionAlarm(),
-                      onChanged: (value) => context
-                          .read<SettingsModel>()
-                          .setPromotionAlarm(value),
-                    ),
-                  ),
-                ),
-                Visibility(
-                  visible: context.watch<SettingsModel>().getSendAlarm(),
-                  child: _buildListTile(
-                    title: "settings.notification.information".tr(),
-                    trailing: CupertinoSwitch(
-                      value: context
-                          .watch<SettingsModel>()
-                          .getInformationAlarm(),
-                      onChanged: (value) => context
-                          .read<SettingsModel>()
-                          .setInformationAlarm(value),
-                    ),
-                  ),
-                ),
-                _buildListTile(
-                  title: "settings.send_error_log".tr(),
-                  subtitle: "settings.send_error_log_desc".tr(),
-                  trailing: CupertinoSwitch(
-                    value: context.watch<SettingsModel>().getSendCrashlytics(),
-                    onChanged: (value) =>
-                        context.read<SettingsModel>().setSendCrashlytics(value),
-                  ),
-                ),
-                Visibility(
-                  visible: context.watch<SettingsModel>().getSendCrashlytics(),
-                  child: _buildListTile(
-                    title: "settings.send_anonymously".tr(),
-                    subtitle: "settings.send_anonymously_desc".tr(),
-                    trailing: CupertinoSwitch(
-                      value: context
-                          .watch<SettingsModel>()
-                          .getSendCrashlyticsAnonymously(),
-                      onChanged: (value) => context
-                          .read<SettingsModel>()
-                          .setSendCrashlyticsAnonymously(value),
-                    ),
-                  ),
-                ),
-                _buildListTile(
-                  title: "settings.show_channel_talk_button".tr(),
-                  trailing: CupertinoSwitch(
-                    value: context
-                        .watch<SettingsModel>()
-                        .getShowsChannelTalkButton(),
-                    onChanged: (value) {
-                      context.read<SettingsModel>().setShowsChannelTalkButton(
-                        value,
+                  _buildListTile(
+                    title: "settings.reset_all".tr(),
+                    onTap: () {
+                      OTLNavigator.pushDialog(
+                        context: context,
+                        builder: (_) => OTLDialog(
+                          type: OTLDialogType.resetSettings,
+                          onTapPos: () => context
+                              .read<SettingsModel>()
+                              .clearAllValues(),
+                        ),
                       );
-
-                      if (!value) {
-                        ChannelTalk.hideChannelButton();
-                      } else {
-                        ChannelTalk.showChannelButton();
-                      }
                     },
                   ),
-                ),
-                Visibility(
-                  visible: kDebugMode,
-                  child: _buildListTile(
-                    title: "settings.throw_test".tr(),
-                    subtitle: "settings.throw_test_desc".tr(),
-                    onTap: () => throw Exception(),
-                  ),
-                ),
-                _buildListTile(
-                  title: "settings.reset_all".tr(),
-                  onTap: () {
-                    OTLNavigator.pushDialog(
+                  _buildListTile(
+                    title: "settings.about".tr(),
+                    onTap: () => OTLNavigator.pushDialog(
                       context: context,
                       builder: (_) => OTLDialog(
-                        type: OTLDialogType.resetSettings,
-                        onTapPos: () =>
-                            context.read<SettingsModel>().clearAllValues(),
-                      ),
-                    );
-                  },
-                ),
-                _buildListTile(
-                  title: "settings.about".tr(),
-                  onTap: () => OTLNavigator.pushDialog(
-                    context: context,
-                    builder: (_) => OTLDialog(
-                      type: OTLDialogType.about,
-                      onTapContent: () =>
-                          launchUrl(Uri.parse("mailto:$CONTACT")),
-                      onTapPos: () => showLicensePage(
-                        context: context,
-                        applicationName: "",
-                        applicationIcon: Image.asset(
-                          "assets/images/logo.png",
-                          height: 48.0,
+                        type: OTLDialogType.about,
+                        onTapContent: () =>
+                            launchUrl(Uri.parse("mailto:$CONTACT")),
+                        onTapPos: () => showLicensePage(
+                          context: context,
+                          applicationName: "",
+                          applicationIcon: Image.asset(
+                            "assets/images/logo.png",
+                            height: 48.0,
+                          ),
                         ),
                       ),
                     ),
                   ),
-                ),
-              ],
+                ],
               ),
             ),
           ),

--- a/lib/providers/settings_model.dart
+++ b/lib/providers/settings_model.dart
@@ -1,14 +1,24 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final _kSendCrashlytics = 'sendCrashlytics';
 final _kSendCrashlyticsAnonymously = 'sendCrashlyticsAnonymously';
 final _kShowsChannelTalkButton = 'showsChannelTalkButton';
+final _kSendAlarm = 'sendAlarm';
+final _kPromotionAlarm = 'promotionAlarm';
+final _kInformationAlarm = 'informationAlarm';
+final _kSubjectSuggestionAlarm = 'subjectSuggestionAlarm';
 
 class SettingsModel extends ChangeNotifier {
   bool _sendCrashlytics = true;
   bool _sendCrashlyticsAnonymously = false;
   bool _showsChannelTalkButton = true;
+  bool _sendAlarm = false;
+  bool _promotionAlarm = false;
+  bool _informationAlarm = false;
+  bool _subjectSuggestionAlarm = false;
 
   bool getSendCrashlytics() => _sendCrashlytics;
   void setSendCrashlytics(bool newValue) {
@@ -37,11 +47,85 @@ class SettingsModel extends ChangeNotifier {
     );
   }
 
+  bool getSendAlarm() => _sendAlarm;
+  Future<void> setSendAlarm(bool newValue) async {
+    if (newValue) {
+      final status = await Permission.notification.status;
+      if (!status.isGranted) {
+        final result = await Permission.notification.request();
+        if (!result.isGranted) {
+          openAppSettings();
+          return;
+        }
+      }
+    }
+
+    _sendAlarm = newValue;
+    notifyListeners();
+    SharedPreferences.getInstance().then(
+      (instance) => instance.setBool(_kSendAlarm, newValue),
+    );
+
+    _setPromotionAlarm(newValue);
+    _setInformationAlarm(newValue);
+    _setSubjectSuggestionAlarm(newValue);
+  }
+
+  bool getPromotionAlarm() => _promotionAlarm;
+  void setPromotionAlarm(bool newValue) => _setPromotionAlarm(newValue);
+  void _setPromotionAlarm(bool newValue) {
+    _promotionAlarm = newValue;
+    notifyListeners();
+    SharedPreferences.getInstance().then(
+      (instance) => instance.setBool(_kPromotionAlarm, newValue),
+    );
+    if (newValue) {
+      FirebaseMessaging.instance.subscribeToTopic('promotion');
+    } else {
+      FirebaseMessaging.instance.unsubscribeFromTopic('promotion');
+    }
+  }
+
+  bool getInformationAlarm() => _informationAlarm;
+  void setInformationAlarm(bool newValue) => _setInformationAlarm(newValue);
+  void _setInformationAlarm(bool newValue) {
+    _informationAlarm = newValue;
+    notifyListeners();
+    SharedPreferences.getInstance().then(
+      (instance) => instance.setBool(_kInformationAlarm, newValue),
+    );
+    if (newValue) {
+      FirebaseMessaging.instance.subscribeToTopic('information');
+    } else {
+      FirebaseMessaging.instance.unsubscribeFromTopic('information');
+    }
+  }
+
+  bool getSubjectSuggestionAlarm() => _subjectSuggestionAlarm;
+  void setSubjectSuggestionAlarm(bool newValue) =>
+      _setSubjectSuggestionAlarm(newValue);
+  void _setSubjectSuggestionAlarm(bool newValue) {
+    _subjectSuggestionAlarm = newValue;
+    notifyListeners();
+    SharedPreferences.getInstance().then(
+      (instance) => instance.setBool(_kSubjectSuggestionAlarm, newValue),
+    );
+    if (newValue) {
+      FirebaseMessaging.instance.subscribeToTopic('subject_suggestion');
+    } else {
+      FirebaseMessaging.instance.unsubscribeFromTopic('subject_suggestion');
+    }
+  }
+
   SettingsModel({bool forTest = false}) {
     if (forTest) {
       _sendCrashlytics = true;
       _sendCrashlyticsAnonymously = false;
       _showsChannelTalkButton = true;
+      _sendAlarm = false;
+      _promotionAlarm = false;
+      _informationAlarm = false;
+      _subjectSuggestionAlarm = false;
     } else {
       _loadPreferences();
     }
@@ -62,13 +146,26 @@ class SettingsModel extends ChangeNotifier {
         instance.getBool(_kSendCrashlyticsAnonymously) ?? false;
     final newShowsChannelTalkButton =
         instance.getBool(_kShowsChannelTalkButton) ?? true;
+    final newSendAlarm = instance.getBool(_kSendAlarm) ?? false;
+    final newPromotionAlarm = instance.getBool(_kPromotionAlarm) ?? false;
+    final newInformationAlarm = instance.getBool(_kInformationAlarm) ?? false;
+    final newSubjectSuggestionAlarm =
+        instance.getBool(_kSubjectSuggestionAlarm) ?? false;
 
     if (_sendCrashlytics != newSendCrashlytics ||
         _sendCrashlyticsAnonymously != newSendCrashlyticsAnonymously ||
-        _showsChannelTalkButton != newShowsChannelTalkButton) {
+        _showsChannelTalkButton != newShowsChannelTalkButton ||
+        _sendAlarm != newSendAlarm ||
+        _promotionAlarm != newPromotionAlarm ||
+        _informationAlarm != newInformationAlarm ||
+        _subjectSuggestionAlarm != newSubjectSuggestionAlarm) {
       _sendCrashlytics = newSendCrashlytics;
       _sendCrashlyticsAnonymously = newSendCrashlyticsAnonymously;
       _showsChannelTalkButton = newShowsChannelTalkButton;
+      _sendAlarm = newSendAlarm;
+      _promotionAlarm = newPromotionAlarm;
+      _informationAlarm = newInformationAlarm;
+      _subjectSuggestionAlarm = newSubjectSuggestionAlarm;
       notifyListeners();
     }
   }
@@ -76,6 +173,11 @@ class SettingsModel extends ChangeNotifier {
   Future<bool> clearAllValues() async {
     final instance = await SharedPreferences.getInstance();
     final success = await instance.clear();
+
+    FirebaseMessaging.instance.unsubscribeFromTopic('promotion');
+    FirebaseMessaging.instance.unsubscribeFromTopic('information');
+    FirebaseMessaging.instance.unsubscribeFromTopic('subject_suggestion');
+
     getAllValues(instance);
     return success;
   }

--- a/lib/widgets/otl_dialog.dart
+++ b/lib/widgets/otl_dialog.dart
@@ -37,6 +37,8 @@ enum OTLDialogType {
 
   resetSettings,
 
+  notificationConsent,
+
   about,
 }
 
@@ -134,6 +136,14 @@ extension OTLDialogTypeExt on OTLDialogType {
       content: 'settings.dialog.reset_settings_desc',
       icon: 'alert',
       posText: 'settings.dialog.reset',
+    ),
+    OTLDialogType.notificationConsent: _OTLDialogData(
+      title: 'settings.notification.consent_title',
+      content: 'settings.notification.consent_desc',
+      icon: 'alert',
+      negText: 'settings.notification.decline',
+      posText: 'settings.notification.accept',
+      btnStyle: BtnStyle.even,
     ),
     OTLDialogType.about: _OTLDialogData(
       title: 'Online Timeplanner with Lectures Plus @ KAIST',
@@ -268,6 +278,7 @@ class OTLDialog extends StatelessWidget {
       case OTLDialogType.deleteAccount:
       case OTLDialogType.accountDeleted:
       case OTLDialogType.resetSettings:
+      case OTLDialogType.notificationConsent:
         return Text(content, style: bodyRegular);
       case OTLDialogType.addOverlappingLecture:
       case OTLDialogType.addOverlappingLectureWithTab:


### PR DESCRIPTION
## Summary

FCM 기반 알림 토픽 구독 기능과 알림 설정 UI를 추가합니다.

### Changes
- **Settings**: 알림 받기 마스터 토글 + 하위 토픽별 토글 (광고성, 정보성, 과목 제안)
- **FCM Topics**: `promotion`, `information`, `subject_suggestion` 토픽 구독/해지
- **Consent Dialog**: 첫 로그인 시 알림 수신 동의 다이얼로그
- **Permission**: 알림 권한 미허용 시 설정 앱으로 이동
- **i18n**: 한국어/영어 번역 추가

### Related PRs
Closes #194, Supersedes #210

### Screenshots
설정 페이지에 알림 섹션이 추가되며, 앱 첫 실행 시 알림 동의 다이얼로그가 표시됩니다.