### PR TITLE
feat(timetable): Add Custom Block support

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -80,7 +80,10 @@
       "ask_delete_lecture": "Do you want to delete lecture '{lecture}'?",
       "ask_delete_lecture_with_tab": "Do you want to delete lecture '{lecture}' from {timetable}?",
       "ask_delete_tab": "Do you really want to delete {timetable}?",
-      "disabled_delete_last_tab": "You can't delete the last timetable."
+      "disabled_delete_last_tab": "You can't delete the last timetable.",
+      "add_custom_block": "Add Custom Block",
+      "delete_custom_block": "Delete Custom Block",
+      "ask_delete_custom_block": "Do you want to delete '{block}'?"
     },
     "tab_menu": {
       "copy": "Copy Timetable",
@@ -109,6 +112,13 @@
       "fri": "Fri",
       "sat": "Sat",
       "sun": "Sun"
+    },
+    "custom_block": {
+      "block_name": "Block Name",
+      "place": "Place",
+      "day": "Day",
+      "start_time": "Start Time",
+      "end_time": "End Time"
     }
   },
   "dictionary": {

--- a/assets/translations/ko.json
+++ b/assets/translations/ko.json
@@ -80,7 +80,10 @@
       "ask_delete_lecture": "'{lecture}' 수업을 삭제하시겠습니까?",
       "ask_delete_lecture_with_tab": "'{lecture}' 수업을 {timetable}에서 삭제하시겠습니까?",
       "ask_delete_tab": "{timetable}을(를) 정말 삭제하시겠습니까?",
-      "disabled_delete_last_tab": "마지막 시간표는 삭제할 수 없습니다."
+      "disabled_delete_last_tab": "마지막 시간표는 삭제할 수 없습니다.",
+      "add_custom_block": "커스텀 블록 추가",
+      "delete_custom_block": "커스텀 블록 삭제",
+      "ask_delete_custom_block": "'{block}' 블록을 삭제하시겠습니까?"
     },
     "tab_menu": {
       "copy": "시간표 복제하기",
@@ -109,6 +112,13 @@
       "fri": "금요일",
       "sat": "토요일",
       "sun": "일요일"
+    },
+    "custom_block": {
+      "block_name": "블록 이름",
+      "place": "장소",
+      "day": "요일",
+      "start_time": "시작 시간",
+      "end_time": "종료 시간"
     }
   },
   "dictionary": {

--- a/lib/constants/url.dart
+++ b/lib/constants/url.dart
@@ -19,6 +19,10 @@ const API_TIMETABLE_ADD_LECTURE_URL =
     API_TIMETABLE_URL + "/{timetable_id}/add-lecture";
 const API_TIMETABLE_REMOVE_LECTURE_URL =
     API_TIMETABLE_URL + "/{timetable_id}/remove-lecture";
+const API_CUSTOM_BLOCK_URL =
+    API_URL + "v2/timetables/{timetable_id}/custom-blocks";
+const API_CUSTOM_BLOCK_DETAIL_URL =
+    API_CUSTOM_BLOCK_URL + "/{block_id}";
 const API_LIKED_REVIEW_URL = API_URL + "/users/{user_id}/liked-reviews";
 const API_SHARE_URL = API_URL + "share/timetable/{share_type}";
 

--- a/lib/models/custom_block.dart
+++ b/lib/models/custom_block.dart
@@ -1,0 +1,68 @@
+import 'package:otlplus/models/time.dart';
+
+class CustomBlockTime extends Time {
+  final String place;
+
+  CustomBlockTime({
+    required this.place,
+    required int day,
+    required int begin,
+    required int end,
+  }) : super(day: day, begin: begin, end: end);
+
+  @override
+  List<Object> get props => super.props..add(place);
+}
+
+class CustomBlock {
+  final int id;
+  final String blockName;
+  final String place;
+  final int day;
+  final int begin;
+  final int end;
+
+  CustomBlock({
+    required this.id,
+    required this.blockName,
+    required this.place,
+    required this.day,
+    required this.begin,
+    required this.end,
+  });
+
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is CustomBlock && other.id == id);
+
+  @override
+  int get hashCode => id.hashCode;
+
+  CustomBlockTime get time => CustomBlockTime(
+        place: place,
+        day: day,
+        begin: begin,
+        end: end,
+      );
+
+  factory CustomBlock.fromJson(Map<String, dynamic> json) {
+    return CustomBlock(
+      id: json['id'],
+      blockName: json['block_name'] ?? '',
+      place: json['place'] ?? '',
+      day: json['day'],
+      begin: json['begin'],
+      end: json['end'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = Map<String, dynamic>();
+    data['id'] = this.id;
+    data['block_name'] = this.blockName;
+    data['place'] = this.place;
+    data['day'] = this.day;
+    data['begin'] = this.begin;
+    data['end'] = this.end;
+    return data;
+  }
+}

--- a/lib/models/timetable.dart
+++ b/lib/models/timetable.dart
@@ -1,10 +1,16 @@
+import 'package:otlplus/models/custom_block.dart';
 import 'package:otlplus/models/lecture.dart';
 
 class Timetable {
   final int id;
   late List<Lecture> lectures;
+  late List<CustomBlock> customBlocks;
 
-  Timetable({required this.id, required this.lectures});
+  Timetable({
+    required this.id,
+    required this.lectures,
+    List<CustomBlock>? customBlocks,
+  }) : customBlocks = customBlocks ?? [];
 
   bool operator ==(Object other) =>
       identical(this, other) || (other is Timetable && other.id == id);
@@ -21,12 +27,22 @@ class Timetable {
     } else {
       lectures = [];
     }
+    if (json['custom_blocks'] != null) {
+      customBlocks = [];
+      json['custom_blocks'].forEach((v) {
+        customBlocks.add(CustomBlock.fromJson(v));
+      });
+    } else {
+      customBlocks = [];
+    }
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = Map<String, dynamic>();
     data['id'] = this.id;
     data['lectures'] = this.lectures.map((v) => v.toJson()).toList();
+    data['custom_blocks'] =
+        this.customBlocks.map((v) => v.toJson()).toList();
     return data;
   }
 }

--- a/lib/pages/timetable_page.dart
+++ b/lib/pages/timetable_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:otlplus/models/custom_block.dart';
 import 'package:otlplus/pages/lecture_detail_page.dart';
 import 'package:otlplus/pages/lecture_search_page.dart';
 import 'package:otlplus/utils/navigator.dart';
 import 'package:otlplus/providers/lecture_search_model.dart';
+import 'package:otlplus/widgets/custom_block_dialog.dart';
+import 'package:otlplus/widgets/custom_block_tile.dart';
 import 'package:otlplus/widgets/otl_dialog.dart';
 import 'package:otlplus/widgets/lecture_search.dart';
 import 'package:otlplus/widgets/map_view.dart';
@@ -41,6 +44,9 @@ class _TimetablePageState extends State<TimetablePage> {
   Widget _buildBody(BuildContext context) {
     final lectures = context.select<TimetableModel, List<Lecture>>(
       (model) => model.currentTimetable.lectures,
+    );
+    final customBlocks = context.select<TimetableModel, List<CustomBlock>>(
+      (model) => model.currentTimetable.customBlocks,
     );
     final mode = context.select<TimetableModel, int>(
       (model) => model.selectedMode,
@@ -92,27 +98,56 @@ class _TimetablePageState extends State<TimetablePage> {
                           ),
                         ),
                         if (mode == 0)
-                          GestureDetector(
-                            behavior: HitTestBehavior.translucent,
-                            onTap: () {
-                              OTLNavigator.push(
-                                context,
-                                LectureSearchPage(openKeyboard: false),
-                              );
-                            },
-                            child: Padding(
-                              padding: const EdgeInsets.fromLTRB(
-                                12,
-                                18,
-                                16,
-                                18,
+                          Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              if (context.read<TimetableModel>().selectedIndex != 0)
+                                GestureDetector(
+                                  behavior: HitTestBehavior.translucent,
+                                  onTap: () {
+                                    OTLNavigator.pushDialog(
+                                      context: context,
+                                      builder: (_) =>
+                                          const AddCustomBlockDialog(),
+                                    );
+                                  },
+                                  child: Padding(
+                                    padding: const EdgeInsets.fromLTRB(
+                                      8,
+                                      18,
+                                      4,
+                                      18,
+                                    ),
+                                    child: Icon(
+                                      Icons.add_box_outlined,
+                                      size: 24,
+                                      color: OTLColor.pinksMain,
+                                    ),
+                                  ),
+                                ),
+                              GestureDetector(
+                                behavior: HitTestBehavior.translucent,
+                                onTap: () {
+                                  OTLNavigator.push(
+                                    context,
+                                    LectureSearchPage(openKeyboard: false),
+                                  );
+                                },
+                                child: Padding(
+                                  padding: const EdgeInsets.fromLTRB(
+                                    4,
+                                    18,
+                                    16,
+                                    18,
+                                  ),
+                                  child: Icon(
+                                    Icons.search,
+                                    size: 24,
+                                    color: OTLColor.pinksMain,
+                                  ),
+                                ),
                               ),
-                              child: Icon(
-                                Icons.search,
-                                size: 24,
-                                color: OTLColor.pinksMain,
-                              ),
-                            ),
+                            ],
                           )
                         else
                           const SizedBox(width: 16),
@@ -127,6 +162,7 @@ class _TimetablePageState extends State<TimetablePage> {
                           return _buildTimetableMode(
                             context,
                             lectures,
+                            customBlocks,
                             mode == 1,
                           );
                         default:
@@ -158,6 +194,7 @@ class _TimetablePageState extends State<TimetablePage> {
   Widget _buildTimetableMode(
     BuildContext context,
     List<Lecture> lectures,
+    List<CustomBlock> customBlocks,
     bool isExamTime,
   ) {
     return Column(
@@ -169,7 +206,7 @@ class _TimetablePageState extends State<TimetablePage> {
               child: Container(
                 color: OTLColor.grayF,
                 padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: _buildTimetable(context, lectures, isExamTime),
+                child: _buildTimetable(context, lectures, customBlocks, isExamTime),
               ),
             ),
           ),
@@ -182,6 +219,7 @@ class _TimetablePageState extends State<TimetablePage> {
   Timetable _buildTimetable(
     BuildContext context,
     List<Lecture> lectures,
+    List<CustomBlock> customBlocks,
     bool isExamTime,
   ) {
     bool isFirst = true;
@@ -191,7 +229,22 @@ class _TimetablePageState extends State<TimetablePage> {
 
     return Timetable(
       lectures: (tempLecture == null) ? lectures : [...lectures, tempLecture],
+      customBlocks: isExamTime ? null : customBlocks,
       isExamTime: isExamTime,
+      customBlockBuilder: (block, blockHeight) {
+        return CustomBlockTile(
+          block: block,
+          height: blockHeight,
+          onLongPress: context.read<TimetableModel>().selectedIndex == 0
+              ? null
+              : () {
+                  OTLNavigator.pushDialog(
+                    context: context,
+                    builder: (_) => DeleteCustomBlockDialog(block: block),
+                  );
+                },
+        );
+      },
       builder: (lecture, classTimeIndex, blockHeight) {
         final isSelected = tempLecture == lecture;
         Key? key;

--- a/lib/providers/timetable_model.dart
+++ b/lib/providers/timetable_model.dart
@@ -4,6 +4,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:otlplus/constants/url.dart';
 import 'package:otlplus/dio_provider.dart';
+import 'package:otlplus/models/custom_block.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/models/semester.dart';
 import 'package:otlplus/models/timetable.dart';
@@ -136,6 +137,11 @@ class TimetableModel extends ChangeNotifier {
       _timetables = rawTimetables
           .map((timetable) => Timetable.fromJson(timetable))
           .toList();
+
+      // Fetch custom blocks for each timetable
+      for (int i = 0; i < _timetables.length; i++) {
+        await _loadCustomBlocks(_timetables[i]);
+      }
 
       List<Lecture> myLecturesList = _user.myTimetableLectures
           .where(
@@ -283,6 +289,119 @@ class TimetableModel extends ChangeNotifier {
       );
 
       writeFile(type, response.data);
+      return true;
+    } catch (exception) {
+      print(exception);
+    }
+    return false;
+  }
+
+  Future<void> _loadCustomBlocks(Timetable timetable) async {
+    try {
+      final response = await DioProvider().dio.get(
+        API_CUSTOM_BLOCK_URL.replaceFirst(
+          "{timetable_id}",
+          timetable.id.toString(),
+        ),
+      );
+      if (response.data != null && response.data['custom_blocks'] != null) {
+        timetable.customBlocks = (response.data['custom_blocks'] as List)
+            .map((v) => CustomBlock.fromJson(v))
+            .toList();
+      }
+    } catch (exception) {
+      print(exception);
+    }
+  }
+
+  Future<bool> addCustomBlock({
+    required String blockName,
+    required String place,
+    required int day,
+    required int begin,
+    required int end,
+  }) async {
+    try {
+      final response = await DioProvider().dio.post(
+        API_CUSTOM_BLOCK_URL.replaceFirst(
+          "{timetable_id}",
+          currentTimetable.id.toString(),
+        ),
+        data: {
+          "block_name": blockName,
+          "place": place,
+          "day": day,
+          "begin": begin,
+          "end": end,
+        },
+      );
+      final newBlock = CustomBlock(
+        id: response.data['id'],
+        blockName: blockName,
+        place: place,
+        day: day,
+        begin: begin,
+        end: end,
+      );
+      currentTimetable.customBlocks.add(newBlock);
+      notifyListeners();
+      return true;
+    } catch (exception) {
+      print(exception);
+    }
+    return false;
+  }
+
+  Future<bool> removeCustomBlock({required CustomBlock block}) async {
+    try {
+      await DioProvider().dio.delete(
+        API_CUSTOM_BLOCK_DETAIL_URL
+            .replaceFirst(
+              "{timetable_id}",
+              currentTimetable.id.toString(),
+            )
+            .replaceFirst("{block_id}", block.id.toString()),
+      );
+      currentTimetable.customBlocks.remove(block);
+      notifyListeners();
+      return true;
+    } catch (exception) {
+      print(exception);
+    }
+    return false;
+  }
+
+  Future<bool> updateCustomBlock({
+    required CustomBlock block,
+    String? blockName,
+    String? place,
+  }) async {
+    try {
+      final data = <String, dynamic>{};
+      if (blockName != null) data['block_name'] = blockName;
+      if (place != null) data['place'] = place;
+
+      await DioProvider().dio.patch(
+        API_CUSTOM_BLOCK_DETAIL_URL
+            .replaceFirst(
+              "{timetable_id}",
+              currentTimetable.id.toString(),
+            )
+            .replaceFirst("{block_id}", block.id.toString()),
+        data: data,
+      );
+      final index = currentTimetable.customBlocks.indexOf(block);
+      if (index >= 0) {
+        currentTimetable.customBlocks[index] = CustomBlock(
+          id: block.id,
+          blockName: blockName ?? block.blockName,
+          place: place ?? block.place,
+          day: block.day,
+          begin: block.begin,
+          end: block.end,
+        );
+      }
+      notifyListeners();
       return true;
     } catch (exception) {
       print(exception);

--- a/lib/widgets/custom_block_dialog.dart
+++ b/lib/widgets/custom_block_dialog.dart
@@ -1,0 +1,365 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:otlplus/constants/color.dart';
+import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/models/custom_block.dart';
+import 'package:otlplus/providers/timetable_model.dart';
+import 'package:otlplus/utils/navigator.dart';
+import 'package:otlplus/widgets/responsive_button.dart';
+import 'package:provider/provider.dart';
+
+const _DAYS_KO = ['월', '화', '수', '목', '금'];
+const _DAYS_EN = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
+class AddCustomBlockDialog extends StatefulWidget {
+  const AddCustomBlockDialog({Key? key}) : super(key: key);
+
+  @override
+  State<AddCustomBlockDialog> createState() => _AddCustomBlockDialogState();
+}
+
+class _AddCustomBlockDialogState extends State<AddCustomBlockDialog> {
+  final _nameController = TextEditingController();
+  final _placeController = TextEditingController();
+  int _selectedDay = 0;
+  int _beginHour = 9;
+  int _beginMin = 0;
+  int _endHour = 10;
+  int _endMin = 0;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _placeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isKo = context.locale == Locale('ko');
+    final days = isKo ? _DAYS_KO : _DAYS_EN;
+
+    return Center(
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          width: 300,
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(
+            color: OTLColor.grayF,
+            borderRadius: BorderRadius.circular(10),
+            boxShadow: [
+              BoxShadow(
+                color: OTLColor.gray0.withValues(alpha: .15),
+                offset: const Offset(2, 2),
+                blurRadius: 16,
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                isKo ? '커스텀 블록 추가' : 'Add Custom Block',
+                style: titleBold,
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _nameController,
+                decoration: InputDecoration(
+                  labelText: isKo ? '블록 이름' : 'Block Name',
+                  labelStyle: bodyRegular.copyWith(color: OTLColor.gray75),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  contentPadding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                ),
+                style: bodyRegular,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _placeController,
+                decoration: InputDecoration(
+                  labelText: isKo ? '장소' : 'Place',
+                  labelStyle: bodyRegular.copyWith(color: OTLColor.gray75),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  contentPadding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                ),
+                style: bodyRegular,
+              ),
+              const SizedBox(height: 12),
+              Text(isKo ? '요일' : 'Day', style: labelBold),
+              const SizedBox(height: 6),
+              Wrap(
+                spacing: 6,
+                children: List.generate(5, (i) {
+                  final selected = _selectedDay == i;
+                  return GestureDetector(
+                    onTap: () => setState(() => _selectedDay = i),
+                    child: Container(
+                      width: 40,
+                      height: 32,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: selected ? OTLColor.pinksMain : OTLColor.grayE,
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Text(
+                        days[i],
+                        style: labelBold.copyWith(
+                          color: selected ? OTLColor.grayF : OTLColor.gray3,
+                        ),
+                      ),
+                    ),
+                  );
+                }),
+              ),
+              const SizedBox(height: 12),
+              Text(isKo ? '시작 시간' : 'Start Time', style: labelBold),
+              const SizedBox(height: 6),
+              _buildTimePicker(
+                hour: _beginHour,
+                minute: _beginMin,
+                onHourChanged: (h) => setState(() => _beginHour = h),
+                onMinChanged: (m) => setState(() => _beginMin = m),
+              ),
+              const SizedBox(height: 12),
+              Text(isKo ? '종료 시간' : 'End Time', style: labelBold),
+              const SizedBox(height: 6),
+              _buildTimePicker(
+                hour: _endHour,
+                minute: _endMin,
+                onHourChanged: (h) => setState(() => _endHour = h),
+                onMinChanged: (m) => setState(() => _endMin = m),
+              ),
+              const SizedBox(height: 20),
+              Row(
+                children: [
+                  Expanded(
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(24),
+                      child: BackgroundButton(
+                        color: OTLColor.grayE,
+                        onTap: () => OTLNavigator.pop(context),
+                        child: Container(
+                          height: 36,
+                          alignment: Alignment.center,
+                          child: Text(
+                            'common.cancel'.tr(),
+                            style: bodyBold.copyWith(color: OTLColor.gray0),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(24),
+                      child: BackgroundButton(
+                        color: OTLColor.pinksMain,
+                        onTap: () {
+                          final name = _nameController.text.trim();
+                          if (name.isEmpty) return;
+
+                          final begin = _beginHour * 60 + _beginMin;
+                          final end = _endHour * 60 + _endMin;
+                          if (end <= begin) return;
+
+                          context.read<TimetableModel>().addCustomBlock(
+                                blockName: name,
+                                place: _placeController.text.trim(),
+                                day: _selectedDay,
+                                begin: begin,
+                                end: end,
+                              );
+                          OTLNavigator.pop(context);
+                        },
+                        child: Container(
+                          height: 36,
+                          alignment: Alignment.center,
+                          child: Text(
+                            'common.add'.tr(),
+                            style: bodyBold.copyWith(color: OTLColor.grayF),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTimePicker({
+    required int hour,
+    required int minute,
+    required ValueChanged<int> onHourChanged,
+    required ValueChanged<int> onMinChanged,
+  }) {
+    return Row(
+      children: [
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            decoration: BoxDecoration(
+              border: Border.all(color: OTLColor.grayD),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<int>(
+                value: hour,
+                isExpanded: true,
+                style: bodyRegular.copyWith(color: OTLColor.gray0),
+                items: List.generate(15, (i) => i + 8).map((h) {
+                  return DropdownMenuItem(
+                    value: h,
+                    child: Text('${h.toString().padLeft(2, '0')}'),
+                  );
+                }).toList(),
+                onChanged: (v) {
+                  if (v != null) onHourChanged(v);
+                },
+              ),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Text(':', style: titleBold),
+        ),
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            decoration: BoxDecoration(
+              border: Border.all(color: OTLColor.grayD),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<int>(
+                value: minute,
+                isExpanded: true,
+                style: bodyRegular.copyWith(color: OTLColor.gray0),
+                items: [0, 15, 30, 45].map((m) {
+                  return DropdownMenuItem(
+                    value: m,
+                    child: Text('${m.toString().padLeft(2, '0')}'),
+                  );
+                }).toList(),
+                onChanged: (v) {
+                  if (v != null) onMinChanged(v);
+                },
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class DeleteCustomBlockDialog extends StatelessWidget {
+  final CustomBlock block;
+
+  const DeleteCustomBlockDialog({Key? key, required this.block})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final isKo = context.locale == Locale('ko');
+
+    return Center(
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          width: 256,
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(
+            color: OTLColor.grayF,
+            borderRadius: BorderRadius.circular(10),
+            boxShadow: [
+              BoxShadow(
+                color: OTLColor.gray0.withValues(alpha: .15),
+                offset: const Offset(2, 2),
+                blurRadius: 16,
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.delete_outline, size: 48, color: OTLColor.pinksMain),
+              const SizedBox(height: 16),
+              Text(
+                isKo ? '커스텀 블록 삭제' : 'Delete Custom Block',
+                style: titleBold,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                isKo
+                    ? "'${block.blockName}' 블록을 삭제하시겠습니까?"
+                    : "Do you want to delete '${block.blockName}'?",
+                style: bodyRegular,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 20),
+              Row(
+                children: [
+                  Expanded(
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(24),
+                      child: BackgroundButton(
+                        color: OTLColor.grayE,
+                        onTap: () => OTLNavigator.pop(context),
+                        child: Container(
+                          height: 30,
+                          alignment: Alignment.center,
+                          child: Text(
+                            'common.cancel'.tr(),
+                            style: bodyBold.copyWith(color: OTLColor.gray0),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(24),
+                      child: BackgroundButton(
+                        color: OTLColor.pinksMain,
+                        onTap: () {
+                          context
+                              .read<TimetableModel>()
+                              .removeCustomBlock(block: block);
+                          OTLNavigator.pop(context);
+                        },
+                        child: Container(
+                          height: 30,
+                          alignment: Alignment.center,
+                          child: Text(
+                            'common.delete'.tr(),
+                            style: bodyBold.copyWith(color: OTLColor.grayF),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/custom_block_tile.dart
+++ b/lib/widgets/custom_block_tile.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:otlplus/constants/color.dart';
+import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/models/custom_block.dart';
+import 'package:otlplus/widgets/responsive_button.dart';
+
+const _customBlockColor = Color(0xFFD4E6F1);
+
+class CustomBlockTile extends StatelessWidget {
+  final CustomBlock block;
+  final double height;
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+
+  CustomBlockTile({
+    Key? key,
+    required this.block,
+    this.height = 78,
+    this.onTap,
+    this.onLongPress,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final contents = <Widget>[];
+
+    contents.add(
+      Text(
+        block.blockName,
+        style: labelRegular.copyWith(
+          color: OTLColor.gray0,
+          overflow: TextOverflow.ellipsis,
+        ),
+        maxLines: 2,
+      ),
+    );
+
+    if (block.place.isNotEmpty) {
+      contents.add(
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              block.place,
+              style: labelRegular.copyWith(
+                color: OTLColor.gray6,
+                overflow: TextOverflow.ellipsis,
+                fontSize: 10,
+              ),
+              maxLines: 1,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(2.0),
+      child: BackgroundButton(
+        color: _customBlockColor,
+        onTap: onTap,
+        onLongPress: onLongPress,
+        child: Padding(
+          padding: const EdgeInsets.all(6.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: contents,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/timetable.dart
+++ b/lib/widgets/timetable.dart
@@ -2,8 +2,10 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:otlplus/constants/color.dart';
 import 'package:otlplus/models/classtime.dart';
+import 'package:otlplus/models/custom_block.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/models/time.dart';
+import 'package:otlplus/widgets/custom_block_tile.dart';
 import 'package:otlplus/widgets/timetable_block.dart';
 
 const DAYSOFWEEK = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
@@ -12,8 +14,10 @@ class Timetable extends StatelessWidget {
   double get _dividerHeight => dividerPadding.vertical + 1;
 
   final _lectures = List.generate(7, (i) => Map<Time, Lecture>());
+  final _customBlocks = List.generate(7, (i) => <CustomBlock>[]);
 
   final TimetableBlock Function(Lecture, int, double) builder;
+  final Widget Function(CustomBlock, double)? customBlockBuilder;
   final double fontSize;
   final EdgeInsetsGeometry dividerPadding;
   final int daysCount;
@@ -21,6 +25,8 @@ class Timetable extends StatelessWidget {
   Timetable({
     required List<Lecture> lectures,
     required this.builder,
+    this.customBlockBuilder,
+    List<CustomBlock>? customBlocks,
     bool isExamTime = false,
     this.fontSize = 10.0,
     this.dividerPadding = const EdgeInsets.fromLTRB(0, 6, 0, 7),
@@ -38,6 +44,14 @@ class Timetable extends StatelessWidget {
           (classtime) => _lectures[classtime.day][classtime] = lecture,
         ),
       );
+    }
+
+    if (customBlocks != null && !isExamTime) {
+      for (final block in customBlocks) {
+        if (block.day >= 0 && block.day < 7) {
+          _customBlocks[block.day].add(block);
+        }
+      }
     }
   }
 
@@ -144,6 +158,28 @@ class Timetable extends StatelessWidget {
     );
   }
 
+  Widget _buildCustomBlock({required CustomBlock block}) {
+    final begin = block.begin / 30 - 18;
+    final end = block.end / 30 - 18;
+    final top = _dividerHeight * (2 * begin + 0.5) + 1 - begin;
+    final bottom = _dividerHeight * (2 * end + 0.5) + 1 - end - 3;
+
+    return Positioned(
+      top: top,
+      left: 0,
+      right: 0,
+      height: bottom - top,
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: dividerPadding.horizontal / 3,
+        ),
+        child: customBlockBuilder != null
+            ? customBlockBuilder!(block, bottom - top)
+            : CustomBlockTile(block: block, height: bottom - top),
+      ),
+    );
+  }
+
   Widget _buildColumn(int i) {
     return Expanded(
       child: Padding(
@@ -163,6 +199,9 @@ class Timetable extends StatelessWidget {
                 _buildCells(),
                 ..._lectures[i].entries.map(
                   (e) => _buildLectureBlock(lecture: e.value, time: e.key),
+                ),
+                ..._customBlocks[i].map(
+                  (block) => _buildCustomBlock(block: block),
                 ),
               ],
             ),


### PR DESCRIPTION
Implement Custom Block CRUD for timetable.

## Changes
- Added `CustomBlock` model (`lib/models/custom_block.dart`) with `fromJson`/`toJson` using snake_case API fields
- Updated `Timetable` model to include `customBlocks` list with JSON deserialization
- Added API URL constants for custom block endpoints (`API_CUSTOM_BLOCK_URL`, `API_CUSTOM_BLOCK_DETAIL_URL`)
- Updated `TimetableModel` provider with:
  - `_loadCustomBlocks()` — fetches custom blocks for each timetable on load
  - `addCustomBlock()` — POST to create a new custom block
  - `removeCustomBlock()` — DELETE a custom block
  - `updateCustomBlock()` — PATCH to update block name/place
- Created `CustomBlockTile` widget for rendering custom blocks on the timetable grid
- Updated `Timetable` widget to render custom blocks alongside lectures
- Added `AddCustomBlockDialog` with day selector, time pickers, and block name/place fields
- Added `DeleteCustomBlockDialog` with confirmation prompt
- Added "커스텀 블록 추가" button (add_box_outlined icon) next to search in timetable toolbar
- Long-press on custom block opens delete confirmation dialog
- Added Korean/English localization strings for custom block UI
- Matches web frontend implementation (otlplus-web-v4 PR #132)

## API Endpoints Used
- GET `/api/v2/timetables/:id/custom-blocks`
- POST `/api/v2/timetables/:id/custom-blocks`
- PATCH `/api/v2/timetables/:id/custom-blocks/:blockId`
- DELETE `/api/v2/timetables/:id/custom-blocks/:blockId`