### PR TITLE
feat(ui): redesign account + settings surfaces (PR 3/3, depends on foundation)

### DIFF
--- a/lib/pages/people_page.dart
+++ b/lib/pages/people_page.dart
@@ -1,8 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/widgets/otl_scaffold.dart';
 
 class PeoplePage extends StatelessWidget {
@@ -12,23 +11,25 @@ class PeoplePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return OTLScaffold(
       child: OTLLayout(
-        middle: Text('title.credit'.tr(), style: titleBold),
+        middle: Text('title.credit'.tr(), style: context.texts.bigBold),
         body: ColoredBox(
-          color: OTLColor.grayF,
+          color: context.colors.backgroundPageDefault,
           child: SingleChildScrollView(
             child: Padding(
               padding: EdgeInsets.all(16.0),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  _buildContainer('2023.03 ~'),
-                  ..._get202303(),
+                  _buildContainer(context, '2023.03 ~'),
+                  ..._get202303(context),
                   const SizedBox(height: 32.0),
-                  _buildContainer('2020.03 ~ 2023.02'),
+                  _buildContainer(context, '2020.03 ~ 2023.02'),
                   const SizedBox(height: 12.0),
                   Text(
                     'common.coming'.tr(),
-                    style: bodyRegular.copyWith(color: OTLColor.grayA),
+                    style: context.texts.normal.copyWith(
+                      color: context.colors.textDisable,
+                    ),
                   ),
                 ],
               ),
@@ -39,19 +40,19 @@ class PeoplePage extends StatelessWidget {
     );
   }
 
-  _buildContainer(String title) {
+  _buildContainer(BuildContext context, String title) {
     return Container(
       padding: EdgeInsets.symmetric(vertical: 6.0),
       decoration: BoxDecoration(
-        color: OTLColor.pinksLight,
+        color: context.colors.backgroundPageDefault,
         borderRadius: BorderRadius.circular(16.0),
       ),
       width: double.infinity,
-      child: Center(child: Text(title, style: titleRegular)),
+      child: Center(child: Text(title, style: context.texts.big)),
     );
   }
 
-  List<Widget> _get202303() {
+  List<Widget> _get202303(BuildContext context) {
     const List<String> positions = [
       'Project Manager',
       'Tech Lead',
@@ -76,12 +77,15 @@ class PeoplePage extends StatelessWidget {
       ['platypus', 'star', 'lobe', 'seungho', 'soongyu', 'edge'],
     ];
 
+    // legacy: SPARCS brand color — not part of OTL design tokens
+    const sparcsColor = Color(0xFFEBA12A);
+
     return List.generate(
       4,
       (i) => Column(
         children: [
           const SizedBox(height: 12.0),
-          Text(positions[i], style: labelBold),
+          Text(positions[i], style: context.texts.smallBold),
           ...List.generate(
             people[i].length,
             (j) => Column(
@@ -96,7 +100,7 @@ class PeoplePage extends StatelessWidget {
                     Text(
                       people[i][j],
                       style: TextStyle(
-                        color: Color(0xFFEBA12A),
+                        color: sparcsColor, // legacy: SPARCS brand
                         fontSize: 15,
                         fontFamily: 'Raleway',
                         fontWeight: FontWeight.w800,
@@ -110,7 +114,9 @@ class PeoplePage extends StatelessWidget {
                       child: Text(
                         people_info[people[i][j]]['name'],
                         style: TextStyle(
-                          color: Color(0xFFEBA12A).withValues(alpha: .4),
+                          color: sparcsColor.withValues(
+                            alpha: .4,
+                          ), // legacy: SPARCS brand
                           fontFamily: 'NanumSquare',
                           fontSize: 9.5,
                           fontWeight: FontWeight.w800,

--- a/lib/pages/privacy_page.dart
+++ b/lib/pages/privacy_page.dart
@@ -1,8 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
 import 'package:otlplus/constants/privacy.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/widgets/otl_scaffold.dart';
 
 class PrivacyPage extends StatelessWidget {
@@ -12,16 +11,16 @@ class PrivacyPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return OTLScaffold(
       child: OTLLayout(
-        middle: Text('title.privacy'.tr(), style: titleBold),
+        middle: Text('title.privacy'.tr(), style: context.texts.bigBold),
         body: ColoredBox(
-          color: OTLColor.grayF,
+          color: context.colors.backgroundPageDefault,
           child: Padding(
             padding: EdgeInsets.all(16.0),
             child: ListView(
               children: [
                 Text.rich(
                   TextSpan(
-                    style: bodyRegular,
+                    style: context.texts.normal,
                     children: <TextSpan>[
                       TextSpan(
                         text: privacyText0,
@@ -32,7 +31,7 @@ class PrivacyPage extends StatelessWidget {
                               TextSpan(text: '\n'),
                               TextSpan(
                                 text: privacyTitles[index],
-                                style: bodyBold,
+                                style: context.texts.normalBold,
                               ),
                               TextSpan(text: '\n'),
                               TextSpan(text: privacyTexts[index]),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
 import 'package:otlplus/constants/url.dart';
 import 'package:otlplus/providers/settings_model.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/widgets/dropdown.dart';
 import 'package:otlplus/widgets/otl_dialog.dart';
 import 'package:otlplus/utils/navigator.dart';
@@ -21,9 +20,9 @@ class SettingsPage extends StatelessWidget {
 
     return OTLScaffold(
       child: OTLLayout(
-        middle: Text('title.settings'.tr(), style: titleBold),
+        middle: Text('title.settings'.tr(), style: context.texts.bigBold),
         body: ColoredBox(
-          color: OTLColor.grayF,
+          color: context.colors.backgroundPageDefault,
           child: Padding(
             padding: const EdgeInsets.all(16.0),
             child: SingleChildScrollView(
@@ -32,26 +31,32 @@ class SettingsPage extends StatelessWidget {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      Text("settings.language".tr(), style: bodyBold),
+                      Text(
+                        "settings.language".tr(),
+                        style: context.texts.normalBold,
+                      ),
                       Dropdown<bool>(
                         customButton: Container(
                           height: 34,
                           padding: const EdgeInsets.symmetric(horizontal: 16),
                           decoration: BoxDecoration(
-                            color: OTLColor.pinksLight,
+                            color: context.colors.backgroundPageDefault,
                             borderRadius: BorderRadius.circular(20),
                           ),
                           child: Row(
                             children: [
-                              Icon(Icons.language, color: OTLColor.pinksMain),
+                              Icon(
+                                Icons.language,
+                                color: context.colors.highlightDefault,
+                              ),
                               const SizedBox(width: 8),
                               Text(
                                 isEn
                                     ? "settings.english".tr()
                                     : "settings.korean".tr(),
-                                style: bodyBold.copyWith(
+                                style: context.texts.normalBold.copyWith(
                                   height: 1.2,
-                                  color: OTLColor.pinksMain,
+                                  color: context.colors.highlightDefault,
                                 ),
                               ),
                             ],
@@ -86,6 +91,7 @@ class SettingsPage extends StatelessWidget {
                     ],
                   ),
                   _buildListTile(
+                    context,
                     title: "settings.notification.receive".tr(),
                     subtitle: "settings.notification.receive_desc".tr(),
                     trailing: CupertinoSwitch(
@@ -97,6 +103,7 @@ class SettingsPage extends StatelessWidget {
                   Visibility(
                     visible: context.watch<SettingsModel>().getSendAlarm(),
                     child: _buildListTile(
+                      context,
                       title: "settings.notification.subject_suggestion".tr(),
                       trailing: CupertinoSwitch(
                         value: context
@@ -111,6 +118,7 @@ class SettingsPage extends StatelessWidget {
                   Visibility(
                     visible: context.watch<SettingsModel>().getSendAlarm(),
                     child: _buildListTile(
+                      context,
                       title: "settings.notification.promotion".tr(),
                       trailing: CupertinoSwitch(
                         value: context
@@ -125,6 +133,7 @@ class SettingsPage extends StatelessWidget {
                   Visibility(
                     visible: context.watch<SettingsModel>().getSendAlarm(),
                     child: _buildListTile(
+                      context,
                       title: "settings.notification.information".tr(),
                       trailing: CupertinoSwitch(
                         value: context
@@ -137,6 +146,7 @@ class SettingsPage extends StatelessWidget {
                     ),
                   ),
                   _buildListTile(
+                    context,
                     title: "settings.send_error_log".tr(),
                     subtitle: "settings.send_error_log_desc".tr(),
                     trailing: CupertinoSwitch(
@@ -153,6 +163,7 @@ class SettingsPage extends StatelessWidget {
                         .watch<SettingsModel>()
                         .getSendCrashlytics(),
                     child: _buildListTile(
+                      context,
                       title: "settings.send_anonymously".tr(),
                       subtitle: "settings.send_anonymously_desc".tr(),
                       trailing: CupertinoSwitch(
@@ -166,6 +177,7 @@ class SettingsPage extends StatelessWidget {
                     ),
                   ),
                   _buildListTile(
+                    context,
                     title: "settings.show_channel_talk_button".tr(),
                     trailing: CupertinoSwitch(
                       value: context
@@ -187,12 +199,14 @@ class SettingsPage extends StatelessWidget {
                   Visibility(
                     visible: kDebugMode,
                     child: _buildListTile(
+                      context,
                       title: "settings.throw_test".tr(),
                       subtitle: "settings.throw_test_desc".tr(),
                       onTap: () => throw Exception(),
                     ),
                   ),
                   _buildListTile(
+                    context,
                     title: "settings.reset_all".tr(),
                     onTap: () {
                       OTLNavigator.pushDialog(
@@ -206,6 +220,7 @@ class SettingsPage extends StatelessWidget {
                     },
                   ),
                   _buildListTile(
+                    context,
                     title: "settings.about".tr(),
                     onTap: () => OTLNavigator.pushDialog(
                       context: context,
@@ -233,7 +248,8 @@ class SettingsPage extends StatelessWidget {
     );
   }
 
-  Widget _buildListTile({
+  Widget _buildListTile(
+    BuildContext context, {
     required String title,
     String? subtitle,
     Widget? trailing,
@@ -253,10 +269,10 @@ class SettingsPage extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(title, style: bodyBold),
+                    Text(title, style: context.texts.normalBold),
                     if (subtitle != null) ...[
                       const SizedBox(height: 4),
-                      Text(subtitle, style: bodyRegular),
+                      Text(subtitle, style: context.texts.normal),
                     ],
                   ],
                 ),

--- a/lib/pages/user_page.dart
+++ b/lib/pages/user_page.dart
@@ -2,16 +2,15 @@ import 'dart:io';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/text_styles.dart';
 import 'package:otlplus/pages/liked_review_page.dart';
 import 'package:otlplus/pages/my_review_page.dart';
 import 'package:otlplus/providers/auth_model.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/utils/navigator.dart';
 import 'package:otlplus/widgets/otl_dialog.dart';
 import 'package:otlplus/widgets/responsive_button.dart';
 import 'package:otlplus/widgets/otl_scaffold.dart';
 import 'package:provider/provider.dart';
-import 'package:otlplus/constants/color.dart';
 import 'package:otlplus/providers/info_model.dart';
 
 class UserPage extends StatelessWidget {
@@ -22,9 +21,9 @@ class UserPage extends StatelessWidget {
 
     return OTLScaffold(
       child: OTLLayout(
-        middle: Text('title.my_information'.tr(), style: titleBold),
+        middle: Text('title.my_information'.tr(), style: context.texts.bigBold),
         body: ColoredBox(
-          color: OTLColor.grayF,
+          color: context.colors.backgroundPageDefault,
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 16.0),
             child: Column(
@@ -35,12 +34,18 @@ class UserPage extends StatelessWidget {
                   child: Column(
                     children: [
                       _buildContent(
+                        context,
                         "user.name",
                         "${user.firstName} ${user.lastName}",
                       ),
-                      _buildContent("user.email", user.email),
-                      _buildContent("user.student_id", user.studentId),
+                      _buildContent(context, "user.email", user.email),
                       _buildContent(
+                        context,
+                        "user.student_id",
+                        user.studentId,
+                      ),
+                      _buildContent(
+                        context,
                         "user.major",
                         user.majors
                             .map(
@@ -49,7 +54,7 @@ class UserPage extends StatelessWidget {
                             )
                             .join(", "),
                       ),
-                      _buildDivider(),
+                      _buildDivider(context),
                     ],
                   ),
                 ),
@@ -67,14 +72,14 @@ class UserPage extends StatelessWidget {
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: _buildDivider(),
+                  child: _buildDivider(context),
                 ),
-                _buildAccount('assets/icons/logout.svg', () {
+                _buildAccount(context, 'assets/icons/logout.svg', () {
                   context.read<AuthModel>().logout();
                   OTLNavigator.pop(context);
                 }, 'user.logout'.tr()),
                 if (Platform.isIOS)
-                  _buildAccount(Icons.highlight_off, () {
+                  _buildAccount(context, Icons.highlight_off, () {
                     OTLNavigator.pushDialog(
                       context: context,
                       builder: (_) => OTLDialog(
@@ -95,18 +100,18 @@ class UserPage extends StatelessWidget {
     );
   }
 
-  Widget _buildDivider() {
-    return Divider(color: OTLColor.gray0.withValues(alpha: .25));
+  Widget _buildDivider(BuildContext context) {
+    return Divider(color: context.colors.lineDivider);
   }
 
-  Widget _buildContent(String title, String body) {
+  Widget _buildContent(BuildContext context, String title, String body) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8.0),
       child: Row(
         children: [
-          Text(title.tr(), style: bodyBold),
+          Text(title.tr(), style: context.texts.normalBold),
           const SizedBox(width: 8.0),
-          Text(body),
+          Text(body, style: context.texts.normal),
         ],
       ),
     );
@@ -133,7 +138,7 @@ class UserPage extends StatelessWidget {
                         'arg': icon,
                         'height': 24.0,
                         'width': 24.0,
-                        'color': OTLColor.pinksMain,
+                        'color': context.colors.highlightDefault,
                       },
                     },
                     {
@@ -142,8 +147,8 @@ class UserPage extends StatelessWidget {
                         'child': {
                           'Text': {
                             'arg': text,
-                            'style': bodyBold.copyWith(
-                              color: OTLColor.pinksMain,
+                            'style': context.texts.normalBold.copyWith(
+                              color: context.colors.highlightDefault,
                             ),
                           },
                         },
@@ -156,7 +161,7 @@ class UserPage extends StatelessWidget {
                         'child': {
                           'Icon': {
                             'arg': Icons.navigate_next,
-                            'color': OTLColor.pinksMain,
+                            'color': context.colors.highlightDefault,
                           },
                         },
                       },
@@ -172,15 +177,20 @@ class UserPage extends StatelessWidget {
     );
   }
 
-  Widget _buildAccount(dynamic icon, void Function()? onTap, String? text) {
+  Widget _buildAccount(
+    BuildContext context,
+    dynamic icon,
+    void Function()? onTap,
+    String? text,
+  ) {
     return Align(
       alignment: Alignment.centerLeft,
       child: IconTextButton(
         icon: icon,
         onTap: onTap,
         text: text,
-        color: OTLColor.pinksMain,
-        textStyle: bodyBold,
+        color: context.colors.highlightDefault,
+        textStyle: context.texts.normalBold,
         spaceBetween: 8.0,
         padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 6.0),
       ),

--- a/lib/pages/user_page.dart
+++ b/lib/pages/user_page.dart
@@ -39,11 +39,7 @@ class UserPage extends StatelessWidget {
                         "${user.firstName} ${user.lastName}",
                       ),
                       _buildContent(context, "user.email", user.email),
-                      _buildContent(
-                        context,
-                        "user.student_id",
-                        user.studentId,
-                      ),
+                      _buildContent(context, "user.student_id", user.studentId),
                       _buildContent(
                         context,
                         "user.major",


### PR DESCRIPTION
## Coordinated redesign stream — Stage 3 of 6

This PR migrates **4 files** in the **account + settings** surface from legacy `OTLColor.*` + `lib/constants/text_styles.dart` constants to the new `context.colors` / `context.texts` design-system tokens introduced in **Foundation PR #237**.

| Stage | PR | Domain | Status |
|-------|----|--------|--------|
| 1 | #237 | foundation theme | ready to merge |
| 2 | #238 | home + timetable | draft |
| 3 | #236 | account + settings | draft |
| 4 | #241 | search + dictionary | draft |
| 5 | #240 | course + lecture detail | draft |
| 6 | #239 | reviews | draft |

### Dependency
This PR will **not compile standalone** — it imports `package:otlplus/theme/context_ext.dart` which is introduced in #237. The import error resolves once #237 merges and this branch is rebased onto `main` (use `scripts/rebase-onto-foundation.sh --cleanup` from #237).

---

## Summary

PR 3/3 in the coordinated UI redesign stream. Replaces hardcoded `OTLColor.*` and `text_styles.dart` constants with the new `context.colors` / `context.texts` design-system tokens from `ThemeExtension`.

**⚠️ DEPENDENCY**: This PR will NOT compile until the foundation PR (`ui-redesign/foundation-theme`) is merged first. The import `package:otlplus/theme/context_ext.dart` does not exist yet.

## Token Mapping

| Old (OTLColor / text_styles) | New (context.colors / context.texts) | Usage |
|---|---|---|
| `OTLColor.grayF` | `context.colors.backgroundPageDefault` | Page backgrounds |
| `OTLColor.pinksLight` | `context.colors.backgroundPageDefault` | Language button bg |
| `OTLColor.pinksMain` | `context.colors.highlightDefault` | Accent/highlight |
| `OTLColor.gray0.withAlpha` | `context.colors.lineDivider` | Dividers |
| `OTLColor.grayA` | `context.colors.textDisable` | Disabled/placeholder text |
| `titleBold` | `context.texts.bigBold` | Page titles |
| `titleRegular` | `context.texts.big` | Section headers |
| `bodyBold` | `context.texts.normalBold` | List tile titles, action buttons |
| `bodyRegular` | `context.texts.normal` | Body text, subtitles |
| `labelBold` | `context.texts.smallBold` | Position labels (people page) |

## File-by-File Changes

### `lib/pages/settings_page.dart`
- Removed imports: `color.dart`, `text_styles.dart`
- Added import: `theme/context_ext.dart`
- `OTLColor.grayF` → `context.colors.backgroundPageDefault`
- `OTLColor.pinksLight` → `context.colors.backgroundPageDefault`
- `OTLColor.pinksMain` → `context.colors.highlightDefault`
- `titleBold` → `context.texts.bigBold`
- `bodyBold` → `context.texts.normalBold`
- `bodyRegular` → `context.texts.normal`
- `_buildListTile` now takes `BuildContext` parameter for token access

### `lib/pages/user_page.dart`
- Removed imports: `color.dart`, `text_styles.dart`
- Added import: `theme/context_ext.dart`
- `OTLColor.grayF` → `context.colors.backgroundPageDefault`
- `OTLColor.pinksMain` → `context.colors.highlightDefault`
- `OTLColor.gray0.withValues(alpha: .25)` → `context.colors.lineDivider`
- All text styles migrated to `context.texts.*`
- Helper methods now accept `BuildContext`

### `lib/pages/people_page.dart`
- Removed imports: `color.dart`, `text_styles.dart`
- Added import: `theme/context_ext.dart`
- `OTLColor.grayF` → `context.colors.backgroundPageDefault`
- `OTLColor.pinksLight` → `context.colors.backgroundPageDefault`
- `OTLColor.grayA` → `context.colors.textDisable`
- SPARCS brand color `Color(0xFFEBA12A)` kept as `const sparcsColor` — not an OTL design token
- All text styles migrated

### `lib/pages/privacy_page.dart`
- Removed imports: `color.dart`, `text_styles.dart`
- Added import: `theme/context_ext.dart`
- `OTLColor.grayF` → `context.colors.backgroundPageDefault`
- `bodyRegular` → `context.texts.normal`, `bodyBold` → `context.texts.normalBold`, `titleBold` → `context.texts.bigBold`

### `lib/widgets/pop_up.dart`
- **SKIPPED**: `PopUp` widget is not imported by any owned page. Left for follow-up PR.

## Acceptable Drift

| Token | Drift | Reason |
|---|---|---|
| `OTLColor.pinksLight` → `backgroundPageDefault` | pinksLight was `#F9F0F0` (pinkish), backgroundPageDefault is neutral | Web uses neutral page bg; acceptable visual shift |
| `titleBold` (16px) → `context.texts.bigBold` (16px) | None | Exact match |
| SPARCS brand `Color(0xFFEBA12A)` | Kept as-is | External brand, not part of OTL tokens |

## Dependency

- **BLOCKED ON**: Foundation PR (`ui-redesign/foundation-theme` branch) which creates `lib/theme/context_ext.dart` with `AppColorScheme` and `AppTextTheme` ThemeExtensions
- Foundation branch: [`ui-redesign/foundation-theme`](../../tree/ui-redesign/foundation-theme)
- This PR must remain DRAFT until foundation PR merges

## Behavior Preserved

- Zero changes to state management, navigation, network calls, or widget tree structure
- All `Provider` watch/read calls unchanged
- Platform checks (`Platform.isIOS`) unchanged
- All localization (`tr()`) calls unchanged