### PR TITLE
feat(ui): redesign home + timetable (PR 2/3, depends on foundation)

### DIFF
--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/extensions/semester.dart';
 import 'package:otlplus/pages/course_search_page.dart';
 import 'package:otlplus/pages/lecture_detail_page.dart';
@@ -17,7 +17,6 @@ import 'package:otlplus/widgets/responsive_button.dart';
 import 'package:otlplus/utils/navigator.dart';
 import 'package:otlplus/widgets/otl_scaffold.dart';
 import 'package:provider/provider.dart';
-import 'package:otlplus/constants/color.dart';
 import 'package:otlplus/models/semester.dart';
 import 'package:otlplus/models/timetable.dart';
 import 'package:otlplus/models/user.dart';
@@ -132,7 +131,7 @@ class _MainPageState extends State<MainPage> {
             ),
             icon: 'assets/icons/person.svg',
             iconSize: 24,
-            color: OTLColor.pinksMain,
+            color: context.colors.highlightDefault,
             tapEffect: ButtonTapEffect.darken,
             padding: EdgeInsets.fromLTRB(16.0, 16.0, 8.0, 16.0),
           ),
@@ -144,7 +143,7 @@ class _MainPageState extends State<MainPage> {
             ),
             icon: 'assets/icons/gear.svg',
             iconSize: 24,
-            color: OTLColor.pinksMain,
+            color: context.colors.highlightDefault,
             tapEffect: ButtonTapEffect.darken,
             padding: EdgeInsets.fromLTRB(8.0, 16.0, 16.0, 16.0),
           ),
@@ -182,7 +181,7 @@ class _MainPageState extends State<MainPage> {
                             );
                           },
                           tapEffect: ButtonTapEffect.darken,
-                          color: OTLColor.grayF,
+                          color: context.colors.backgroundSectionDefault,
                           child: Padding(
                             padding: EdgeInsets.symmetric(
                               horizontal: 12.0,
@@ -196,7 +195,7 @@ class _MainPageState extends State<MainPage> {
                                   height: 24.0,
                                   width: 24.0,
                                   colorFilter: ColorFilter.mode(
-                                    OTLColor.pinksMain,
+                                    context.colors.highlightDefault,
                                     BlendMode.srcIn,
                                   ),
                                 ),
@@ -204,8 +203,8 @@ class _MainPageState extends State<MainPage> {
                                 Expanded(
                                   child: Text(
                                     "common.search_hint".tr(),
-                                    style: bodyRegular.copyWith(
-                                      color: OTLColor.grayA,
+                                    style: context.texts.normal.copyWith(
+                                      color: context.colors.textPlaceholder,
                                       height: 1.24,
                                     ),
                                   ),
@@ -224,7 +223,7 @@ class _MainPageState extends State<MainPage> {
                       top: Radius.circular(16.0),
                     ),
                     child: Container(
-                      color: OTLColor.grayF,
+                      color: context.colors.backgroundSectionDefault,
                       constraints: const BoxConstraints.expand(),
                       child: CustomScrollView(
                         reverse: true,
@@ -232,7 +231,7 @@ class _MainPageState extends State<MainPage> {
                           SliverFillRemaining(
                             hasScrollBody: false,
                             child: ColoredBox(
-                              color: OTLColor.grayF,
+                              color: context.colors.backgroundSectionDefault,
                               child: Padding(
                                 padding: const EdgeInsets.symmetric(
                                   horizontal: 16.0,
@@ -274,42 +273,6 @@ class _MainPageState extends State<MainPage> {
                           ),
                         ],
                       ),
-
-                      // SingleChildScrollView(
-                      //   child: ColoredBox(
-                      //     color: Colors.white,
-                      //     child: Padding(
-                      //       padding: const EdgeInsets.symmetric(
-                      //         horizontal: 16.0,
-                      //         vertical: 16.0,
-                      //       ),
-                      //       child: Column(
-                      //         mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      //         children: [
-                      //           Column(
-                      //             children: <Widget>[
-                      //               _buildTimetable(infoModel.user, semester, now),
-                      //               const SizedBox(height: 24.0),
-                      //               _buildDivider(),
-                      //               const SizedBox(height: 24.0),
-                      //               _buildSchedule(now, infoModel.currentSchedule),
-                      //               const SizedBox(height: 24.0),
-                      //               _buildDivider(),
-                      //             ],
-                      //           ),
-                      //           Column(
-                      //             children: <Widget>[
-                      //               _buildLogo(),
-                      //               const SizedBox(height: 4.0),
-                      //               _buildCopyRight(),
-                      //               _buildTextButtons(context),
-                      //             ],
-                      //           )
-                      //         ],
-                      //       ),
-                      //     ),
-                      //   ),
-                      // ),
                     ),
                   ),
                 ),
@@ -322,7 +285,7 @@ class _MainPageState extends State<MainPage> {
   }
 
   Widget _buildDivider() {
-    return Divider(color: OTLColor.gray0.withValues(alpha: .25));
+    return Divider(color: context.colors.textDark.withValues(alpha: .25));
   }
 
   Widget _buildTextButtons(BuildContext context) {
@@ -338,7 +301,9 @@ class _MainPageState extends State<MainPage> {
             );
           },
           text: 'title.privacy'.tr(),
-          textStyle: labelRegular.copyWith(color: OTLColor.gray75),
+          textStyle: context.texts.small.copyWith(
+            color: context.colors.textLighter,
+          ),
           padding: EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
           tapEffect: ButtonTapEffect.lighten,
         ),
@@ -351,7 +316,9 @@ class _MainPageState extends State<MainPage> {
             );
           },
           text: 'title.credit'.tr(),
-          textStyle: labelRegular.copyWith(color: OTLColor.gray75),
+          textStyle: context.texts.small.copyWith(
+            color: context.colors.textLighter,
+          ),
           padding: EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
           tapEffect: ButtonTapEffect.lighten,
         ),
@@ -366,7 +333,9 @@ class _MainPageState extends State<MainPage> {
   Widget _buildCopyRight() {
     return Text.rich(
       TextSpan(
-        style: labelRegular.copyWith(color: OTLColor.gray75),
+        style: context.texts.small.copyWith(
+          color: context.colors.textLighter,
+        ),
         children: [
           TextSpan(text: 'otlplus@sparcs.org'),
           TextSpan(text: '\n'),
@@ -396,18 +365,18 @@ class _MainPageState extends State<MainPage> {
                     currentSchedule["time"].difference(now) as Duration,
                   ),
                 ),
-          style: titleRegular,
+          style: context.texts.big,
           textAlign: TextAlign.center,
         ),
         const SizedBox(height: 4.0),
         (currentSchedule == null)
-            ? Text('-', style: bodyBold)
+            ? Text('-', style: context.texts.normalBold)
             : Wrap(
                 alignment: WrapAlignment.center,
                 children: [
                   Text(
                     '${(currentSchedule["semester"] as Semester).title} ${(currentSchedule["name"] as String).tr()}',
-                    style: bodyBold,
+                    style: context.texts.normalBold,
                     textAlign: TextAlign.center,
                   ),
                   const SizedBox(width: 4),
@@ -415,7 +384,7 @@ class _MainPageState extends State<MainPage> {
                     DateFormat(
                       "yyyy.MM.dd",
                     ).format(currentSchedule["time"].toLocal()),
-                    style: bodyRegular,
+                    style: context.texts.normal,
                     textAlign: TextAlign.center,
                   ),
                 ],

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -333,9 +333,7 @@ class _MainPageState extends State<MainPage> {
   Widget _buildCopyRight() {
     return Text.rich(
       TextSpan(
-        style: context.texts.small.copyWith(
-          color: context.colors.textLighter,
-        ),
+        style: context.texts.small.copyWith(color: context.colors.textLighter),
         children: [
           TextSpan(text: 'otlplus@sparcs.org'),
           TextSpan(text: '\n'),

--- a/lib/pages/timetable_page.dart
+++ b/lib/pages/timetable_page.dart
@@ -10,7 +10,7 @@ import 'package:otlplus/widgets/otl_scaffold.dart';
 import 'package:otlplus/widgets/semester_picker.dart';
 import 'package:otlplus/widgets/timetable_mode_control.dart';
 import 'package:provider/provider.dart';
-import 'package:otlplus/constants/color.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/providers/lecture_detail_model.dart';
 import 'package:otlplus/providers/timetable_model.dart';
@@ -69,7 +69,7 @@ class _TimetablePageState extends State<TimetablePage> {
         children: <Widget>[
           Expanded(
             child: ColoredBox(
-              color: OTLColor.grayF,
+              color: context.colors.backgroundSectionDefault,
               child: Column(
                 children: <Widget>[
                   SizedBox(
@@ -78,11 +78,11 @@ class _TimetablePageState extends State<TimetablePage> {
                       children: [
                         Expanded(
                           child: Container(
-                            color: OTLColor.pinksLight,
+                            color: context.colors.backgroundPageDefault,
                             child: Container(
                               padding: const EdgeInsets.symmetric(vertical: 16),
                               decoration: BoxDecoration(
-                                color: OTLColor.grayF,
+                                color: context.colors.backgroundSectionDefault,
                                 borderRadius: BorderRadius.only(
                                   topLeft: Radius.circular(16),
                                 ),
@@ -110,7 +110,7 @@ class _TimetablePageState extends State<TimetablePage> {
                               child: Icon(
                                 Icons.search,
                                 size: 24,
-                                color: OTLColor.pinksMain,
+                                color: context.colors.highlightDefault,
                               ),
                             ),
                           )
@@ -167,7 +167,7 @@ class _TimetablePageState extends State<TimetablePage> {
             child: RepaintBoundary(
               key: _paintKey,
               child: Container(
-                color: OTLColor.grayF,
+                color: context.colors.backgroundSectionDefault,
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: _buildTimetable(context, lectures, isExamTime),
               ),
@@ -255,11 +255,6 @@ class _TimetablePageState extends State<TimetablePage> {
         timetableModel.createTimetable(
           lectures: timetableModel.currentTimetable.lectures,
         );
-        /*if (_isSearchOpened) return;
-        setState(() {
-          _isSearchOpened = true;
-          _selectedLecture = null;
-        });*/
       },
       onDeleteTap: (i) {
         if (i == 0) {

--- a/lib/widgets/lecture_search.dart
+++ b/lib/widgets/lecture_search.dart
@@ -5,7 +5,7 @@ import 'package:otlplus/utils/navigator.dart';
 import 'package:otlplus/pages/lecture_search_page.dart';
 import 'package:otlplus/widgets/responsive_button.dart';
 import 'package:provider/provider.dart';
-import 'package:otlplus/constants/color.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/providers/lecture_detail_model.dart';
 import 'package:otlplus/providers/lecture_search_model.dart';
@@ -33,7 +33,7 @@ class _LectureSearchState extends State<LectureSearch> {
         }
       },
       child: ColoredBox(
-        color: OTLColor.grayF,
+        color: context.colors.backgroundSectionDefault,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
@@ -51,7 +51,7 @@ class _LectureSearchState extends State<LectureSearch> {
                           context,
                           LectureSearchPage(openKeyboard: true),
                         ),
-                        color: OTLColor.pinksLight,
+                        color: context.colors.backgroundPageDefault,
                         child: Padding(
                           padding: EdgeInsets.all(8.0),
                           child: SizedBox(
@@ -65,7 +65,7 @@ class _LectureSearchState extends State<LectureSearch> {
                                   height: 24.0,
                                   width: 24.0,
                                   colorFilter: ColorFilter.mode(
-                                    OTLColor.pinksMain,
+                                    context.colors.highlightDefault,
                                     BlendMode.srcIn,
                                   ),
                                 ),

--- a/lib/widgets/map_view.dart
+++ b/lib/widgets/map_view.dart
@@ -207,11 +207,7 @@ class _MapViewState extends State<MapView> {
                         color: _darken(
                           _blockColor(
                             context,
-                            widget
-                                .lectures[buildingCode]![i]
-                                .keys
-                                .first
-                                .course,
+                            widget.lectures[buildingCode]![i].keys.first.course,
                           ),
                         ),
                         shape: BoxShape.circle,
@@ -350,8 +346,7 @@ class _MapViewState extends State<MapView> {
                   alignment: Alignment.center,
                   decoration: BoxDecoration(
                     color: _blockColor(context, lecture.course),
-                    borderRadius:
-                        BorderRadius.circular(isMultiLine ? 13 : 100),
+                    borderRadius: BorderRadius.circular(isMultiLine ? 13 : 100),
                   ),
                   child: Text(location, style: context.texts.small),
                 );

--- a/lib/widgets/map_view.dart
+++ b/lib/widgets/map_view.dart
@@ -1,8 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/models/classtime.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/utils/get_text_height.dart';
@@ -33,6 +32,44 @@ const POSITION_OF_LOCATIONS = {
   'W8': {'left': 0.308, 'top': 0.592},
   'W16': {'left': 0.394, 'top': 0.859},
 };
+
+Color _blockColor(BuildContext context, int i) {
+  final c = context.colors;
+  switch (i % 16) {
+    case 0:
+      return c.tileTimetableRed1;
+    case 1:
+      return c.tileTimetableRed2;
+    case 2:
+      return c.tileTimetableOrange1;
+    case 3:
+      return c.tileTimetableOrange2;
+    case 4:
+      return c.tileTimetableYellow1;
+    case 5:
+      return c.tileTimetableYellow2;
+    case 6:
+      return c.tileTimetableGreen1;
+    case 7:
+      return c.tileTimetableGreen2;
+    case 8:
+      return c.tileTimetableGreen3;
+    case 9:
+      return c.tileTimetableBlue1;
+    case 10:
+      return c.tileTimetableBlue2;
+    case 11:
+      return c.tileTimetablePurple1;
+    case 12:
+      return c.tileTimetablePurple2;
+    case 13:
+      return c.tileTimetablePurple2;
+    case 14:
+      return c.tileTimetablePink1;
+    default:
+      return c.tileTimetablePink2;
+  }
+}
 
 class MapView extends StatefulWidget {
   final Map<String, List<Map<Lecture, Classtime>>> _lectures = {};
@@ -103,7 +140,7 @@ class _MapViewState extends State<MapView> {
             widget: Container(
               height: _height + 12,
               padding: EdgeInsets.fromLTRB(50, 0, 50, 12),
-              color: OTLColor.grayF,
+              color: context.colors.backgroundSectionDefault,
               child: Stack(
                 clipBehavior: Clip.none,
                 alignment: Alignment.bottomLeft,
@@ -130,7 +167,7 @@ class _MapViewState extends State<MapView> {
   Widget _buildMapPin(BuildContext context, String buildingCode) {
     List<BoxShadow> boxShadow = [
       BoxShadow(
-        color: OTLColor.gray0.withValues(alpha: .25),
+        color: context.colors.textDark.withValues(alpha: .25),
         blurRadius: 4,
         offset: Offset(0, 4),
       ),
@@ -147,7 +184,7 @@ class _MapViewState extends State<MapView> {
             height: 23,
             padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 6),
             decoration: BoxDecoration(
-              color: OTLColor.grayF,
+              color: context.colors.backgroundSectionDefault,
               borderRadius: BorderRadius.circular(1),
               boxShadow: boxShadow,
             ),
@@ -157,7 +194,7 @@ class _MapViewState extends State<MapView> {
                 if (buildingCode != '기타')
                   Padding(
                     padding: const EdgeInsets.only(right: 4),
-                    child: Text(buildingCode, style: labelBold),
+                    child: Text(buildingCode, style: context.texts.smallBold),
                   ),
                 ...List.generate(
                   widget.lectures[buildingCode]!.length,
@@ -168,12 +205,14 @@ class _MapViewState extends State<MapView> {
                       height: 11,
                       decoration: BoxDecoration(
                         color: _darken(
-                          OTLColor.blockColors[widget
-                                  .lectures[buildingCode]![i]
-                                  .keys
-                                  .first
-                                  .course %
-                              16],
+                          _blockColor(
+                            context,
+                            widget
+                                .lectures[buildingCode]![i]
+                                .keys
+                                .first
+                                .course,
+                          ),
                         ),
                         shape: BoxShape.circle,
                       ),
@@ -210,7 +249,7 @@ class _MapViewState extends State<MapView> {
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
       child: Container(
         decoration: BoxDecoration(
-          color: OTLColor.grayE,
+          color: context.colors.lineDefault,
           borderRadius: BorderRadius.circular(10),
         ),
         child: Material(
@@ -228,11 +267,14 @@ class _MapViewState extends State<MapView> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(_codeToName(buildingCode), style: bodyBold),
+                  Text(
+                    _codeToName(buildingCode),
+                    style: context.texts.normalBold,
+                  ),
                   Divider(
                     height: 15,
                     thickness: 1,
-                    color: OTLColor.gray0.withValues(alpha: .25),
+                    color: context.colors.textDark.withValues(alpha: .25),
                   ),
                   const SizedBox(height: 1),
                   ...List.generate(
@@ -267,7 +309,7 @@ class _MapViewState extends State<MapView> {
             width: 11,
             height: 11,
             decoration: BoxDecoration(
-              color: _darken(OTLColor.blockColors[lecture.course % 16]),
+              color: _darken(_blockColor(context, lecture.course)),
               shape: BoxShape.circle,
             ),
           ),
@@ -278,7 +320,7 @@ class _MapViewState extends State<MapView> {
             padding: const EdgeInsets.symmetric(vertical: 3),
             child: Text(
               _isKo ? lecture.title : lecture.titleEn,
-              style: bodyRegular,
+              style: context.texts.normal,
             ),
           ),
         ),
@@ -296,10 +338,10 @@ class _MapViewState extends State<MapView> {
                     (getTextSize(
                           context,
                           text: location,
-                          style: labelRegular,
+                          style: context.texts.small,
                           maxWidth: 143,
                         ).height ~/
-                        singleHeight(context, labelRegular)) >
+                        singleHeight(context, context.texts.small)) >
                     1;
 
                 return Container(
@@ -307,10 +349,11 @@ class _MapViewState extends State<MapView> {
                   padding: const EdgeInsets.fromLTRB(6, 2, 6, 4),
                   alignment: Alignment.center,
                   decoration: BoxDecoration(
-                    color: OTLColor.blockColors[lecture.course % 16],
-                    borderRadius: BorderRadius.circular(isMultiLine ? 13 : 100),
+                    color: _blockColor(context, lecture.course),
+                    borderRadius:
+                        BorderRadius.circular(isMultiLine ? 13 : 100),
                   ),
-                  child: Text(location, style: labelRegular),
+                  child: Text(location, style: context.texts.small),
                 );
               },
             ),

--- a/lib/widgets/semester_picker.dart
+++ b/lib/widgets/semester_picker.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/widgets/responsive_button.dart';
 import 'package:provider/provider.dart';
 import 'package:otlplus/extensions/semester.dart';
@@ -36,7 +35,7 @@ class _SemesterPickerState extends State<SemesterPicker> {
       padding: const EdgeInsets.all(8.0),
       child: Text(
         context.watch<TimetableModel>().selectedSemester.title,
-        style: displayBold.copyWith(height: 1.448),
+        style: context.texts.biggerBold.copyWith(height: 1.448),
       ),
     );
   }
@@ -54,7 +53,9 @@ class _SemesterPickerState extends State<SemesterPicker> {
           : null,
       icon: Icons.navigate_before_outlined,
       iconSize: 24,
-      color: canGoPreviousSemester ? OTLColor.gray0 : OTLColor.grayA,
+      color: canGoPreviousSemester
+          ? context.colors.textDark
+          : context.colors.textDisable,
       padding: const EdgeInsets.all(4.0),
       tapEffect: canGoPreviousSemester
           ? ButtonTapEffect.lighten
@@ -75,7 +76,9 @@ class _SemesterPickerState extends State<SemesterPicker> {
           : null,
       icon: Icons.navigate_next_outlined,
       iconSize: 24,
-      color: canGoNextSemester ? OTLColor.gray0 : OTLColor.grayA,
+      color: canGoNextSemester
+          ? context.colors.textDark
+          : context.colors.textDisable,
       padding: const EdgeInsets.all(4.0),
       tapEffect: canGoNextSemester
           ? ButtonTapEffect.lighten

--- a/lib/widgets/timetable.dart
+++ b/lib/widgets/timetable.dart
@@ -1,6 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/models/classtime.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/models/time.dart';
@@ -46,7 +46,7 @@ class Timetable extends StatelessWidget {
     return Row(
       children: List.generate(
         daysCount + 1,
-        (i) => (i == 0) ? _buildHeaders() : _buildColumn(i - 1),
+        (i) => (i == 0) ? _buildHeaders() : _buildColumn(context, i - 1),
       ),
     );
   }
@@ -113,9 +113,12 @@ class Timetable extends StatelessWidget {
     );
   }
 
-  Widget _buildCell(int i) {
+  Widget _buildCell(BuildContext context, int i) {
     if (i % 100 == 0)
-      return Container(color: OTLColor.gray0.withValues(alpha: .25), height: 1);
+      return Container(
+        color: context.colors.textDark.withValues(alpha: .25),
+        height: 1,
+      );
     if (i % 50 == 0)
       return Row(
         children: List.generate(
@@ -124,7 +127,7 @@ class Timetable extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 1.0),
               child: Container(
-                color: OTLColor.gray0.withValues(alpha: .25),
+                color: context.colors.textDark.withValues(alpha: .25),
                 height: 1,
               ),
             ),
@@ -134,17 +137,19 @@ class Timetable extends StatelessWidget {
     return SizedBox();
   }
 
-  Widget _buildCells() {
+  Widget _buildCells(BuildContext context) {
     return Column(
       children: List.generate(
         ((2400 - 900) / 25 + 1).toInt(),
-        (i) =>
-            Padding(padding: dividerPadding, child: _buildCell(i * 25 + 900)),
+        (i) => Padding(
+          padding: dividerPadding,
+          child: _buildCell(context, i * 25 + 900),
+        ),
       ),
     );
   }
 
-  Widget _buildColumn(int i) {
+  Widget _buildColumn(BuildContext context, int i) {
     return Expanded(
       child: Padding(
         padding: const EdgeInsets.only(left: 3),
@@ -160,7 +165,7 @@ class Timetable extends StatelessWidget {
             ),
             Stack(
               children: <Widget>[
-                _buildCells(),
+                _buildCells(context),
                 ..._lectures[i].entries.map(
                   (e) => _buildLectureBlock(lecture: e.value, time: e.key),
                 ),

--- a/lib/widgets/timetable_block.dart
+++ b/lib/widgets/timetable_block.dart
@@ -1,10 +1,47 @@
 import 'package:easy_localization/easy_localization.dart' as loc;
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/utils/get_text_height.dart';
 import 'package:otlplus/widgets/responsive_button.dart';
+
+Color _blockColor(BuildContext context, int i) {
+  final c = context.colors;
+  switch (i % 16) {
+    case 0:
+      return c.tileTimetableRed1;
+    case 1:
+      return c.tileTimetableRed2;
+    case 2:
+      return c.tileTimetableOrange1;
+    case 3:
+      return c.tileTimetableOrange2;
+    case 4:
+      return c.tileTimetableYellow1;
+    case 5:
+      return c.tileTimetableYellow2;
+    case 6:
+      return c.tileTimetableGreen1;
+    case 7:
+      return c.tileTimetableGreen2;
+    case 8:
+      return c.tileTimetableGreen3;
+    case 9:
+      return c.tileTimetableBlue1;
+    case 10:
+      return c.tileTimetableBlue2;
+    case 11:
+      return c.tileTimetablePurple1;
+    case 12:
+      return c.tileTimetablePurple2;
+    case 13:
+      return c.tileTimetablePurple2;
+    case 14:
+      return c.tileTimetablePink1;
+    default:
+      return c.tileTimetablePink2;
+  }
+}
 
 class TimetableBlock extends StatelessWidget {
   final Lecture lecture;
@@ -36,7 +73,7 @@ class TimetableBlock extends StatelessWidget {
   Widget build(BuildContext context) {
     final contents = <Widget>[];
     final validHeight = height - 16;
-    final lineHeight = singleHeight(context, labelRegular);
+    final lineHeight = singleHeight(context, context.texts.small);
     int maxLines = (validHeight - lineHeight) ~/ lineHeight;
     final isKo = context.locale == Locale('ko');
     final title = isKo ? lecture.title : lecture.titleEn;
@@ -48,8 +85,10 @@ class TimetableBlock extends StatelessWidget {
       contents.add(
         Text(
           title,
-          style: labelRegular.copyWith(
-            color: isTemp ? OTLColor.grayF : OTLColor.gray0,
+          style: context.texts.small.copyWith(
+            color: isTemp
+                ? context.colors.textBright
+                : context.colors.textDark,
             overflow: TextOverflow.ellipsis,
           ),
           maxLines: 2,
@@ -63,7 +102,7 @@ class TimetableBlock extends StatelessWidget {
               getTextSize(
                 context,
                 text: title,
-                style: labelRegular,
+                style: context.texts.small,
                 maxWidth: 54,
               ).height) ~/
           lineHeight;
@@ -74,8 +113,10 @@ class TimetableBlock extends StatelessWidget {
             padding: const EdgeInsets.only(top: 4),
             child: Text(
               classroomShort,
-              style: labelRegular.copyWith(
-                color: isTemp ? OTLColor.grayE : OTLColor.gray6,
+              style: context.texts.small.copyWith(
+                color: isTemp
+                    ? context.colors.lineDefault
+                    : context.colors.textLighter,
                 overflow: TextOverflow.ellipsis,
                 fontSize: 10,
               ),
@@ -90,10 +131,10 @@ class TimetableBlock extends StatelessWidget {
       borderRadius: BorderRadius.circular(2.0),
       child: BackgroundButton(
         color: isTemp
-            ? OTLColor.pinksMain
+            ? context.colors.highlightDefault
             : isExamTime
-            ? OTLColor.grayE
-            : OTLColor.blockColors[lecture.course % 16],
+            ? context.colors.lineDefault
+            : _blockColor(context, lecture.course),
         onTap: onTap,
         onLongPress: onLongPress,
         child: Padding(

--- a/lib/widgets/timetable_block.dart
+++ b/lib/widgets/timetable_block.dart
@@ -86,9 +86,7 @@ class TimetableBlock extends StatelessWidget {
         Text(
           title,
           style: context.texts.small.copyWith(
-            color: isTemp
-                ? context.colors.textBright
-                : context.colors.textDark,
+            color: isTemp ? context.colors.textBright : context.colors.textDark,
             overflow: TextOverflow.ellipsis,
           ),
           maxLines: 2,

--- a/lib/widgets/timetable_mode_control.dart
+++ b/lib/widgets/timetable_mode_control.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
+import 'package:otlplus/theme/context_ext.dart';
 
 class TimetableModeControl extends StatefulWidget {
   const TimetableModeControl({
@@ -29,7 +29,7 @@ class _TimetableModeControlState extends State<TimetableModeControl> {
       height: 40,
       padding: const EdgeInsets.fromLTRB(4, 4, 16, 4),
       decoration: BoxDecoration(
-        color: OTLColor.grayF,
+        color: context.colors.backgroundSectionDefault,
         borderRadius: BorderRadius.horizontal(left: Radius.circular(20)),
       ),
       child: Stack(
@@ -42,7 +42,7 @@ class _TimetableModeControlState extends State<TimetableModeControl> {
               width: 48,
               height: 32,
               decoration: BoxDecoration(
-                color: OTLColor.pinksMain,
+                color: context.colors.highlightDefault,
                 borderRadius: BorderRadius.circular(16),
               ),
             ),
@@ -61,8 +61,8 @@ class _TimetableModeControlState extends State<TimetableModeControl> {
                   child: Icon(
                     _iconList[index],
                     color: (index == widget.dropdownIndex)
-                        ? OTLColor.grayF
-                        : OTLColor.pinksMain,
+                        ? context.colors.textBright
+                        : context.colors.highlightDefault,
                   ),
                 ),
               );

--- a/lib/widgets/timetable_summary.dart
+++ b/lib/widgets/timetable_summary.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/providers/timetable_model.dart';
 import 'package:provider/provider.dart';
@@ -110,7 +109,7 @@ class TimetableSummary extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 15, horizontal: 16),
       decoration: BoxDecoration(
         border: Border.symmetric(
-          horizontal: BorderSide(color: OTLColor.pinksLight),
+          horizontal: BorderSide(color: context.colors.backgroundPageDefault),
         ),
       ),
       child: Row(
@@ -128,6 +127,7 @@ class TimetableSummary extends StatelessWidget {
                 mainAxisExtent: 45,
               ),
               itemBuilder: (_, index) => _buildAttribute(
+                context,
                 'timetable.summary.${TYPES_SHORT[index]}'.tr(),
                 typeCredit[index],
                 tempLecture?.typeIdx == index,
@@ -135,26 +135,31 @@ class TimetableSummary extends StatelessWidget {
             ),
           ),
           _buildScore(
+            context,
             'timetable.summary.credit'.tr(),
             allCreditCredit.toString(),
             tempLecture != null && tempLecture.credit > 0,
           ),
           _buildScore(
+            context,
             "AU",
             allAuCredit.toString(),
             tempLecture != null && tempLecture.creditAu > 0,
           ),
           _buildScore(
+            context,
             'timetable.summary.grade'.tr(),
             targetNum > 0 ? LETTERS[(grade / targetNum).round()] : "?",
             tempLecture != null && tempLecture.grade > 0,
           ),
           _buildScore(
+            context,
             'timetable.summary.load'.tr(),
             targetNum > 0 ? LETTERS[(load / targetNum).round()] : "?",
             tempLecture != null && tempLecture.load > 0,
           ),
           _buildScore(
+            context,
             'timetable.summary.speech'.tr(),
             targetNum > 0 ? LETTERS[(speech / targetNum).round()] : "?",
             tempLecture != null && tempLecture.speech > 0,
@@ -164,7 +169,12 @@ class TimetableSummary extends StatelessWidget {
     );
   }
 
-  Widget _buildScore(String title, String content, bool highlight) {
+  Widget _buildScore(
+    BuildContext context,
+    String title,
+    String content,
+    bool highlight,
+  ) {
     return Expanded(
       child: Column(
         children: [
@@ -172,8 +182,10 @@ class TimetableSummary extends StatelessWidget {
             height: 26,
             child: Text(
               content,
-              style: titleBold.copyWith(
-                color: highlight ? OTLColor.pinksMain : OTLColor.gray0,
+              style: context.texts.bigBold.copyWith(
+                color: highlight
+                    ? context.colors.highlightDefault
+                    : context.colors.textDark,
               ),
               textAlign: TextAlign.center,
             ),
@@ -182,8 +194,10 @@ class TimetableSummary extends StatelessWidget {
             height: 17,
             child: Text(
               title,
-              style: labelRegular.copyWith(
-                color: highlight ? OTLColor.pinksMain : OTLColor.gray0,
+              style: context.texts.small.copyWith(
+                color: highlight
+                    ? context.colors.highlightDefault
+                    : context.colors.textDark,
               ),
               textAlign: TextAlign.center,
             ),
@@ -193,15 +207,22 @@ class TimetableSummary extends StatelessWidget {
     );
   }
 
-  Widget _buildAttribute(String title, int value, bool highlight) {
+  Widget _buildAttribute(
+    BuildContext context,
+    String title,
+    int value,
+    bool highlight,
+  ) {
     return Row(
       children: [
         SizedBox(
           width: 28,
           child: Text(
             title,
-            style: labelBold.copyWith(
-              color: highlight ? OTLColor.pinksMain : OTLColor.gray0,
+            style: context.texts.smallBold.copyWith(
+              color: highlight
+                  ? context.colors.highlightDefault
+                  : context.colors.textDark,
             ),
           ),
         ),
@@ -209,8 +230,10 @@ class TimetableSummary extends StatelessWidget {
           width: 17,
           child: Text(
             value.toString(),
-            style: labelRegular.copyWith(
-              color: highlight ? OTLColor.pinksMain : OTLColor.gray0,
+            style: context.texts.small.copyWith(
+              color: highlight
+                  ? context.colors.highlightDefault
+                  : context.colors.textDark,
             ),
           ),
         ),

--- a/lib/widgets/timetable_tabs.dart
+++ b/lib/widgets/timetable_tabs.dart
@@ -1,7 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/constants/url.dart';
 import 'package:otlplus/widgets/dropdown.dart';
 
@@ -61,7 +61,7 @@ class _TimetableTabsState extends State<TimetableTabs> {
           height: 28,
           alignment: Alignment.center,
           decoration: BoxDecoration(
-            color: OTLColor.pinksLight,
+            color: context.colors.backgroundPageDefault,
             borderRadius: BorderRadius.circular(20),
           ),
           child: Icon(Icons.add, size: 16),
@@ -73,8 +73,10 @@ class _TimetableTabsState extends State<TimetableTabs> {
       i == 0
           ? 'timetable.my_tab'.tr()
           : 'timetable.tab'.tr(args: [i.toString()]),
-      style: bodyBold.copyWith(
-        color: i == _index ? OTLColor.grayF : OTLColor.gray0,
+      style: context.texts.normalBold.copyWith(
+        color: i == _index
+            ? context.colors.textBright
+            : context.colors.textDark,
       ),
       textAlign: TextAlign.center,
     );
@@ -87,14 +89,18 @@ class _TimetableTabsState extends State<TimetableTabs> {
             height: 28,
             padding: EdgeInsets.fromLTRB(12, 0, 8, 0),
             decoration: BoxDecoration(
-              color: OTLColor.pinksMain,
+              color: context.colors.highlightDefault,
               borderRadius: BorderRadius.circular(100),
             ),
             child: Row(
               children: [
                 text,
                 const SizedBox(width: 6),
-                Icon(Icons.more_vert, color: OTLColor.grayF, size: 16),
+                Icon(
+                  Icons.more_vert,
+                  color: context.colors.textBright,
+                  size: 16,
+                ),
               ],
             ),
           ),
@@ -119,14 +125,9 @@ class _TimetableTabsState extends State<TimetableTabs> {
                 value: 3,
                 text: 'timetable.tab_menu.delete'.tr(),
                 icon: Icons.delete_outlined,
-                textColor: OTLColor.red,
+                textColor: OTLColor.red, // legacy: no web red semantic
               ),
             ],
-            /*ItemData(
-                value: 4,
-                text: 'timetable.tab_menu.syllabus'.tr(),
-                icon: Icons.sticky_note_2_outlined,
-              ),*/
           ],
           offsetFromLeft: true,
           onChanged: (value) {
@@ -134,7 +135,6 @@ class _TimetableTabsState extends State<TimetableTabs> {
             if (value == 1) widget.onExportTap(ShareType.image);
             if (value == 2) widget.onExportTap(ShareType.ical);
             if (value == 3) widget.onDeleteTap(i);
-            // if (value == 4) Pass
           },
         ),
       );
@@ -144,7 +144,7 @@ class _TimetableTabsState extends State<TimetableTabs> {
       height: 28,
       margin: const EdgeInsets.only(right: 8),
       decoration: BoxDecoration(
-        color: OTLColor.pinksLight,
+        color: context.colors.backgroundPageDefault,
         borderRadius: BorderRadius.circular(20),
       ),
       child: GestureDetector(

--- a/lib/widgets/today_timetable.dart
+++ b/lib/widgets/today_timetable.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/models/classtime.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/models/time.dart';
@@ -39,7 +39,7 @@ class TodayTimetable extends StatelessWidget {
         Scrollable.ensureVisible(_timebarKey.currentContext!);
     });
 
-    return Column(children: <Widget>[_buildHeaders(), _buildRow()]);
+    return Column(children: <Widget>[_buildHeaders(), _buildRow(context)]);
   }
 
   Widget _buildHeader(int i) {
@@ -102,9 +102,12 @@ class TodayTimetable extends StatelessWidget {
     );
   }
 
-  Widget _buildCell(int i) {
+  Widget _buildCell(BuildContext context, int i) {
     if (i % 100 == 0)
-      return Container(color: OTLColor.gray0.withValues(alpha: .25), width: 1);
+      return Container(
+        color: context.colors.textDark.withValues(alpha: .25),
+        width: 1,
+      );
     if (i % 50 == 0)
       return Column(
         children: List.generate(
@@ -113,7 +116,7 @@ class TodayTimetable extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 1.0),
               child: Container(
-                color: OTLColor.gray0.withValues(alpha: .25),
+                color: context.colors.textDark.withValues(alpha: .25),
                 width: 1,
               ),
             ),
@@ -123,21 +126,23 @@ class TodayTimetable extends StatelessWidget {
     return SizedBox(width: 2);
   }
 
-  Widget _buildCells() {
+  Widget _buildCells(BuildContext context) {
     return Row(
       children: List.generate(
         ((2400 - 800) / 25 + 1).toInt(),
-        (i) =>
-            Padding(padding: dividerPadding, child: _buildCell(i * 25 + 800)),
+        (i) => Padding(
+          padding: dividerPadding,
+          child: _buildCell(context, i * 25 + 800),
+        ),
       ),
     );
   }
 
-  Widget _buildRow() {
+  Widget _buildRow(BuildContext context) {
     return Expanded(
       child: Stack(
         children: <Widget>[
-          _buildCells(),
+          _buildCells(context),
           ..._lectures.entries.map(
             (e) => _buildLectureBlock(lecture: e.value, time: e.key),
           ),
@@ -149,7 +154,10 @@ class TodayTimetable extends StatelessWidget {
                 1,
             bottom: 0,
             width: 1,
-            child: Container(key: _timebarKey, color: OTLColor.pinksMain),
+            child: Container(
+              key: _timebarKey,
+              color: context.colors.highlightDefault,
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## Coordinated redesign stream — Stage 2 of 6

This PR migrates **11 files** in the **home + timetable** surface from legacy `OTLColor.*` + `lib/constants/text_styles.dart` constants to the new `context.colors` / `context.texts` design-system tokens introduced in **Foundation PR #237**.

| Stage | PR | Domain | Status |
|-------|----|--------|--------|
| 1 | #237 | foundation theme | ready to merge |
| 2 | #238 | home + timetable | draft |
| 3 | #236 | account + settings | draft |
| 4 | #241 | search + dictionary | draft |
| 5 | #240 | course + lecture detail | draft |
| 6 | #239 | reviews | draft |

### Dependency
This PR will **not compile standalone** — it imports `package:otlplus/theme/context_ext.dart` which is introduced in #237. The import error resolves once #237 merges and this branch is rebased onto `main` (use `scripts/rebase-onto-foundation.sh --cleanup` from #237).

---

## Summary
PR 2 of 3 in the coordinated otl-app redesign stream. Migrates 11 widgets/pages across the home + timetable surface from legacy `OTLColor.*` / global text_styles to the new `context.colors` / `context.texts` tokens introduced in the foundation PR.

## Dependency
**This PR is DRAFT and will NOT compile standalone.** Requires the foundation PR (`ui-redesign/foundation-theme`) to merge first, then this branch rebases onto `main`.

## Files changed
- `lib/pages/main_page.dart`
- `lib/pages/timetable_page.dart`
- `lib/widgets/timetable.dart`
- `lib/widgets/timetable_block.dart`
- `lib/widgets/today_timetable.dart`
- `lib/widgets/timetable_summary.dart`
- `lib/widgets/timetable_tabs.dart`
- `lib/widgets/timetable_mode_control.dart`
- `lib/widgets/semester_picker.dart`
- `lib/widgets/map_view.dart`
- `lib/widgets/lecture_search.dart`

## Color mapping
| Legacy | Token |
|--------|-------|
| gray0 | textDark |
| gray3 | textDefault |
| gray5 | textLight |
| gray6/gray75 | textLighter |
| grayA | textDisable / textPlaceholder |
| grayD | lineDark |
| grayE | lineDefault |
| grayF (bg) | backgroundSectionDefault |
| grayF (fg) | textBright |
| pinksLight | backgroundPageDefault |
| pinksMain | highlightDefault |
| blockColors[0..15] | tileTimetable{Red1,Red2,Orange1,Orange2,Yellow1,Yellow2,Green1,Green2,Green3,Blue1,Blue2,Purple1,Purple2,Purple2,Pink1,Pink2} |

## Text style mapping
| Legacy | Token |
|--------|-------|
| labelRegular/Bold | small/smallBold |
| bodyRegular/Bold | normal/normalBold |
| titleRegular/Bold | big/bigBold |
| headlineRegular/Bold | big/bigBold (drift) |
| displayRegular/Bold | bigger/biggerBold |

## Kept as legacy
- `OTLColor.red` in timetable_tabs.dart — no web red semantic token

## Drift notes
- `#666666` → textLighter (web = `#888888`)
- `#EEEEEE` → lineDefault (web = `#E8E8E8`)
- headline 18px → big (16px) — web caps at 16

## Coordinated stream
- PR 1/3 — foundation (`ui-redesign/foundation-theme`) — merge first
- **PR 2/3 — this PR**
- PR 3/3 — #236 account+settings