### PR TITLE
feat(ui): redesign reviews (PR 6/N, depends on foundation)

### DIFF
--- a/lib/pages/liked_review_page.dart
+++ b/lib/pages/liked_review_page.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/pages/course_detail_page.dart';
 import 'package:otlplus/providers/course_detail_model.dart';
 import 'package:otlplus/providers/info_model.dart';
@@ -26,7 +25,7 @@ class LikedReviewPage extends StatelessWidget {
 
     return OTLScaffold(
       child: OTLLayout(
-        middle: Text('user.liked_review'.tr(), style: titleBold),
+        middle: Text('user.liked_review'.tr(), style: context.texts.bigBold),
         body: Container(
           constraints: const BoxConstraints.expand(),
           child: Card(
@@ -87,12 +86,12 @@ class LikedReviewPage extends StatelessWidget {
                                         top: 4.0,
                                         bottom: 12.0,
                                       ),
-                                      child: const Center(
+                                      child: Center(
                                         child: SizedBox(
                                           width: 24,
                                           height: 24,
                                           child: CircularProgressIndicator(
-                                            color: OTLColor.grayE,
+                                            color: context.colors.lineDefault,
                                             strokeWidth: 2,
                                           ),
                                         ),

--- a/lib/pages/my_review_page.dart
+++ b/lib/pages/my_review_page.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/models/semester.dart';
 import 'package:otlplus/models/user.dart';
@@ -41,9 +40,9 @@ class MyReviewPage extends StatelessWidget {
 
     return OTLScaffold(
       child: OTLLayout(
-        middle: Text('user.my_review'.tr(), style: titleBold),
+        middle: Text('user.my_review'.tr(), style: context.texts.bigBold),
         body: ColoredBox(
-          color: OTLColor.grayF,
+          color: context.colors.backgroundSectionDefault,
           child: Padding(
             padding: const EdgeInsets.all(16.0),
             child: SingleChildScrollView(
@@ -59,7 +58,7 @@ class MyReviewPage extends StatelessWidget {
                               padding: const EdgeInsets.only(bottom: 8.0),
                               child: Text(
                                 '${semester.year} ${["", "semester.spring".tr(), "semester.summer".tr(), "semester.fall".tr(), "semester.winter".tr()][semester.semester]}',
-                                style: labelBold,
+                                style: context.texts.smallBold,
                               ),
                             ),
                             ..._buildLectureBlocks(

--- a/lib/pages/review_page.dart
+++ b/lib/pages/review_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/pages/course_detail_page.dart';
 import 'package:otlplus/providers/hall_of_fame_model.dart';
 import 'package:otlplus/utils/navigator.dart';
@@ -115,12 +115,12 @@ class LatestReviewsPage extends StatelessWidget {
                   delegate: SliverChildListDelegate([
                     Padding(
                       padding: const EdgeInsets.only(top: 4.0, bottom: 12.0),
-                      child: const Center(
+                      child: Center(
                         child: SizedBox(
                           width: 24,
                           height: 24,
                           child: CircularProgressIndicator(
-                            color: OTLColor.grayE,
+                            color: context.colors.lineDefault,
                             strokeWidth: 2,
                           ),
                         ),
@@ -173,12 +173,12 @@ class HallOfFamePage extends StatelessWidget {
                   delegate: SliverChildListDelegate([
                     Padding(
                       padding: const EdgeInsets.only(top: 4.0, bottom: 12.0),
-                      child: const Center(
+                      child: Center(
                         child: SizedBox(
                           width: 24,
                           height: 24,
                           child: CircularProgressIndicator(
-                            color: OTLColor.grayE,
+                            color: context.colors.lineDefault,
                             strokeWidth: 2,
                           ),
                         ),

--- a/lib/widgets/hall_of_fame_control.dart
+++ b/lib/widgets/hall_of_fame_control.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/models/semester.dart';
 import 'package:otlplus/providers/hall_of_fame_model.dart';
 import 'package:otlplus/providers/info_model.dart';
@@ -41,7 +40,7 @@ class _HallOfFameControlState extends State<HallOfFameControl> {
         height: 34,
         padding: EdgeInsets.fromLTRB(16, 0, 8, 0),
         decoration: BoxDecoration(
-          color: OTLColor.grayF,
+          color: context.colors.backgroundSectionDefault,
           borderRadius: BorderRadius.circular(100),
         ),
         child: Row(
@@ -50,12 +49,14 @@ class _HallOfFameControlState extends State<HallOfFameControl> {
               _currentSemester == null
                   ? "common.all".tr()
                   : "${_currentSemester?.year} ${_currentSemester?.semester == 1 ? 'semester.spring'.tr() : 'semester.fall'.tr()}",
-              style: bodyBold.copyWith(color: OTLColor.pinksMain),
+              style: context.texts.normalBold.copyWith(
+                color: context.colors.highlightDefault,
+              ),
             ),
             const SizedBox(width: 2.0),
             Icon(
               _isOpen ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
-              color: OTLColor.pinksMain,
+              color: context.colors.highlightDefault,
             ),
           ],
         ),

--- a/lib/widgets/review_block.dart
+++ b/lib/widgets/review_block.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/constants/url.dart';
 import 'package:otlplus/dio_provider.dart';
 import 'package:otlplus/extensions/review.dart';
@@ -48,7 +47,7 @@ class _ReviewBlockState extends State<ReviewBlock> {
           alignment: Alignment.bottomRight,
           children: [
             BackgroundButton(
-              color: OTLColor.grayE,
+              color: context.colors.lineDefault,
               onTap: widget.onTap,
               child: Padding(
                 padding: const EdgeInsets.symmetric(
@@ -60,13 +59,13 @@ class _ReviewBlockState extends State<ReviewBlock> {
                   children: <Widget>[
                     Text.rich(
                       TextSpan(
-                        style: bodyRegular,
+                        style: context.texts.normal,
                         children: <TextSpan>[
                           TextSpan(
                             text: isEn
                                 ? widget.review.lecture.titleEn
                                 : widget.review.lecture.title,
-                            style: bodyBold,
+                            style: context.texts.normalBold,
                           ),
                           const TextSpan(text: " "),
                           TextSpan(
@@ -99,7 +98,9 @@ class _ReviewBlockState extends State<ReviewBlock> {
                     ExpandableText(
                       content.trim(),
                       maxLines: widget.maxLines,
-                      style: bodyRegular.copyWith(color: OTLColor.gray0),
+                      style: context.texts.normal.copyWith(
+                        color: context.colors.textDark,
+                      ),
                     ),
                     const SizedBox(height: 6.0),
                     Row(
@@ -107,34 +108,34 @@ class _ReviewBlockState extends State<ReviewBlock> {
                       children: <Widget>[
                         Text.rich(
                           TextSpan(
-                            style: labelRegular,
+                            style: context.texts.small,
                             children: <TextSpan>[
                               TextSpan(text: "review.likes".tr()),
                               const TextSpan(text: " "),
                               TextSpan(
                                 text: _like.toString(),
-                                style: labelBold,
+                                style: context.texts.smallBold,
                               ),
                               const TextSpan(text: "  "),
                               TextSpan(text: "review.grade".tr()),
                               const TextSpan(text: " "),
                               TextSpan(
                                 text: widget.review.gradeLetter,
-                                style: labelBold,
+                                style: context.texts.smallBold,
                               ),
                               const TextSpan(text: "  "),
                               TextSpan(text: "review.load".tr()),
                               const TextSpan(text: " "),
                               TextSpan(
                                 text: widget.review.loadLetter,
-                                style: labelBold,
+                                style: context.texts.smallBold,
                               ),
                               const TextSpan(text: "  "),
                               TextSpan(text: "review.speech".tr()),
                               const TextSpan(text: " "),
                               TextSpan(
                                 text: widget.review.speechLetter,
-                                style: labelBold,
+                                style: context.texts.smallBold,
                               ),
                             ],
                           ),
@@ -149,21 +150,21 @@ class _ReviewBlockState extends State<ReviewBlock> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 IconTextButton(
-                  color: OTLColor.pinksMain,
+                  color: context.colors.highlightDefault,
                   iconSize: 16.0,
                   icon: _liked
                       ? Icons.thumb_up_alt
                       : Icons.thumb_up_alt_outlined,
                   spaceBetween: 4.0,
                   text: "review.like".tr(),
-                  textStyle: labelRegular,
+                  textStyle: context.texts.small,
                   padding: EdgeInsets.fromLTRB(3, 8, 10, 8),
                   onTap: _liked ? _uploadCancel : _uploadLike,
                 ),
                 IconTextButton(
-                  color: OTLColor.gray5,
+                  color: context.colors.textLight,
                   text: "review.report".tr(),
-                  textStyle: labelRegular,
+                  textStyle: context.texts.small,
                   onTap: _report,
                   padding: EdgeInsets.fromLTRB(3, 8, 10, 8),
                 ),

--- a/lib/widgets/review_mode_control.dart
+++ b/lib/widgets/review_mode_control.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/providers/hall_of_fame_model.dart';
 import 'package:provider/provider.dart';
 
@@ -21,7 +20,7 @@ class _ReviewModeControlState extends State<ReviewModeControl> {
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 4, 4, 4),
       decoration: BoxDecoration(
-        color: OTLColor.grayF,
+        color: context.colors.backgroundSectionDefault,
         borderRadius: BorderRadius.horizontal(right: Radius.circular(21)),
       ),
       child: Stack(
@@ -38,7 +37,7 @@ class _ReviewModeControlState extends State<ReviewModeControl> {
                   child: widget._selectedMode == 1
                       ? Icon(
                           Icons.emoji_events_outlined,
-                          color: OTLColor.pinksMain,
+                          color: context.colors.highlightDefault,
                         )
                       : null,
                 ),
@@ -46,7 +45,7 @@ class _ReviewModeControlState extends State<ReviewModeControl> {
               Container(
                 height: 34,
                 decoration: BoxDecoration(
-                  color: OTLColor.grayF,
+                  color: context.colors.backgroundSectionDefault,
                   borderRadius: BorderRadius.circular(17),
                 ),
                 padding: EdgeInsets.only(left: 12.0, right: 16.0),
@@ -56,14 +55,16 @@ class _ReviewModeControlState extends State<ReviewModeControl> {
                       widget._selectedMode == 0
                           ? Icons.emoji_events_outlined
                           : Icons.whatshot_outlined,
-                      color: OTLColor.grayF,
+                      color: context.colors.textBright,
                     ),
                     const SizedBox(width: 8),
                     Text(
                       widget._selectedMode == 0
                           ? "title.hall_of_fame".tr()
                           : "title.latest_reviews".tr(),
-                      style: titleBold.copyWith(color: OTLColor.grayF),
+                      style: context.texts.bigBold.copyWith(
+                        color: context.colors.textBright,
+                      ),
                     ),
                   ],
                 ),
@@ -76,7 +77,10 @@ class _ReviewModeControlState extends State<ReviewModeControl> {
                   width: widget._selectedMode == 0 ? 48 : 0,
                   padding: EdgeInsets.symmetric(vertical: 4, horizontal: 12),
                   child: widget._selectedMode == 0
-                      ? Icon(Icons.whatshot_outlined, color: OTLColor.pinksMain)
+                      ? Icon(
+                          Icons.whatshot_outlined,
+                          color: context.colors.highlightDefault,
+                        )
                       : null,
                 ),
               ),
@@ -89,7 +93,7 @@ class _ReviewModeControlState extends State<ReviewModeControl> {
             child: Container(
               height: 34,
               decoration: BoxDecoration(
-                color: OTLColor.pinksMain,
+                color: context.colors.highlightDefault,
                 borderRadius: BorderRadius.circular(17),
               ),
               padding: EdgeInsets.only(left: 12.0, right: 16.0),
@@ -99,14 +103,16 @@ class _ReviewModeControlState extends State<ReviewModeControl> {
                     widget._selectedMode == 0
                         ? Icons.emoji_events_outlined
                         : Icons.whatshot_outlined,
-                    color: OTLColor.grayF,
+                    color: context.colors.textBright,
                   ),
                   const SizedBox(width: 8),
                   Text(
                     widget._selectedMode == 0
                         ? "title.hall_of_fame".tr()
                         : "title.latest_reviews".tr(),
-                    style: titleBold.copyWith(color: OTLColor.grayF),
+                    style: context.texts.bigBold.copyWith(
+                      color: context.colors.textBright,
+                    ),
                   ),
                 ],
               ),

--- a/lib/widgets/review_write_block.dart
+++ b/lib/widgets/review_write_block.dart
@@ -2,8 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:dotted_border/dotted_border.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/constants/url.dart';
 import 'package:otlplus/dio_provider.dart';
 import 'package:otlplus/models/lecture.dart';
@@ -58,7 +57,7 @@ class _ReviewWriteBlockState extends State<ReviewWriteBlock> {
       margin: const EdgeInsets.only(bottom: 8.0),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(4.0),
-        color: OTLColor.grayE,
+        color: context.colors.lineDefault,
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 8.0),
@@ -70,13 +69,13 @@ class _ReviewWriteBlockState extends State<ReviewWriteBlock> {
                 padding: const EdgeInsets.only(bottom: 4.0),
                 child: Text.rich(
                   TextSpan(
-                    style: bodyRegular,
+                    style: context.texts.normal,
                     children: <TextSpan>[
                       TextSpan(
                         text: isEn
                             ? widget.lecture.titleEn
                             : widget.lecture.title,
-                        style: bodyBold,
+                        style: context.texts.normalBold,
                       ),
                       const TextSpan(text: " "),
                       TextSpan(
@@ -109,7 +108,7 @@ class _ReviewWriteBlockState extends State<ReviewWriteBlock> {
             Padding(
               padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
               child: DottedBorder(
-                color: OTLColor.grayA,
+                color: context.colors.textDisable,
                 child: SizedBox(
                   height: 140,
                   child: Padding(
@@ -120,13 +119,15 @@ class _ReviewWriteBlockState extends State<ReviewWriteBlock> {
                     child: TextField(
                       controller: _contentTextController,
                       maxLines: null,
-                      style: bodyRegular,
+                      style: context.texts.normal,
                       onChanged: (value) {
                         setState(() {});
                       },
                       decoration: InputDecoration(
                         hintText: "common.review_hint".tr(),
-                        hintStyle: bodyRegular.copyWith(color: OTLColor.grayA),
+                        hintStyle: context.texts.normal.copyWith(
+                          color: context.colors.textPlaceholder,
+                        ),
                       ),
                     ),
                   ),
@@ -140,12 +141,14 @@ class _ReviewWriteBlockState extends State<ReviewWriteBlock> {
               alignment: Alignment.bottomRight,
               child: IconTextButton(
                 padding: EdgeInsets.zero,
-                color: _canUpload() ? OTLColor.pinksMain : OTLColor.grayA,
+                color: _canUpload()
+                    ? context.colors.highlightDefault
+                    : context.colors.textDisable,
                 text: (widget.existingReview == null)
                     ? "common.upload".tr()
                     : "common.edit".tr(),
                 onTap: _canUpload() ? _uploadReview : null,
-                textStyle: labelRegular,
+                textStyle: context.texts.small,
               ),
             ),
           ],
@@ -228,7 +231,7 @@ class _ReviewWriteBlockState extends State<ReviewWriteBlock> {
       padding: const EdgeInsets.symmetric(vertical: 2.0),
       child: Row(
         children: <Widget>[
-          Text(title, style: bodyRegular),
+          Text(title, style: context.texts.normal),
           const SizedBox(width: 4.0),
           _buildOption(type, 5),
           _buildOption(type, 4),
@@ -245,7 +248,9 @@ class _ReviewWriteBlockState extends State<ReviewWriteBlock> {
       padding: const EdgeInsets.only(left: 4.0),
       child: ClipOval(
         child: BackgroundButton(
-          color: (_scores[type] == score) ? OTLColor.gray75 : OTLColor.grayD,
+          color: (_scores[type] == score)
+              ? context.colors.textLighter
+              : context.colors.lineBlock,
           onTap: () {
             setState(() {
               _scores[type] = (_scores[type] == score) ? 0 : score;
@@ -257,10 +262,8 @@ class _ReviewWriteBlockState extends State<ReviewWriteBlock> {
             child: Center(
               child: Text(
                 ["?", "F", "D", "C", "B", "A"][score],
-                style: labelBold.copyWith(
-                  color: _scores[type] == score
-                      ? OTLColor.grayF
-                      : OTLColor.grayF,
+                style: context.texts.smallBold.copyWith(
+                  color: context.colors.textBright,
                 ),
               ),
             ),


### PR DESCRIPTION
## Coordinated redesign stream — Stage 6 of 6

This PR migrates **7 files** in the **reviews** surface from legacy `OTLColor.*` + `lib/constants/text_styles.dart` constants to the new `context.colors` / `context.texts` design-system tokens introduced in **Foundation PR #237**.

| Stage | PR | Domain | Status |
|-------|----|--------|--------|
| 1 | #237 | foundation theme | ready to merge |
| 2 | #238 | home + timetable | draft |
| 3 | #236 | account + settings | draft |
| 4 | #241 | search + dictionary | draft |
| 5 | #240 | course + lecture detail | draft |
| 6 | #239 | reviews | draft |

### Dependency
This PR will **not compile standalone** — it imports `package:otlplus/theme/context_ext.dart` which is introduced in #237. The import error resolves once #237 merges and this branch is rebased onto `main` (use `scripts/rebase-onto-foundation.sh --cleanup` from #237).

---

## Summary

Migrate the reviews surface (7 files) from legacy `OTLColor.*` / `text_styles.dart` constants to the new `AppColorScheme` / `AppTextTheme` design-system tokens introduced in foundation PR #237.

## Depends on

- #237 (foundation theme) — **this PR will not compile until #237 is merged and rebased onto**.

## Files changed

| File | Changes |
|------|---------|
| `lib/pages/review_page.dart` | `OTLColor.grayE` → `context.colors.lineDefault` |
| `lib/pages/liked_review_page.dart` | `OTLColor.grayE` → `lineDefault`, `titleBold` → `context.texts.bigBold` |
| `lib/pages/my_review_page.dart` | `OTLColor.grayF` → `backgroundSectionDefault`, `labelBold`/`titleBold` → `smallBold`/`bigBold` |
| `lib/widgets/review_block.dart` | `grayE`→`lineDefault`, `gray0`→`textDark`, `gray5`→`textLight`, `pinksMain`→`highlightDefault`; all text styles migrated |
| `lib/widgets/review_write_block.dart` | `grayE`→`lineDefault`, `grayA`→`textDisable`/`textPlaceholder`, `gray75`→`textLighter`, `grayD`→`lineBlock`, `grayF`→`textBright`, `pinksMain`→`highlightDefault`; all text styles migrated |
| `lib/widgets/review_mode_control.dart` | `grayF`→`backgroundSectionDefault`/`textBright`, `pinksMain`→`highlightDefault`, `titleBold`→`bigBold` |
| `lib/widgets/hall_of_fame_control.dart` | `grayF`→`backgroundSectionDefault`, `pinksMain`→`highlightDefault`, `bodyBold`→`normalBold` |

## Color mapping reference

| Legacy | Token |
|--------|-------|
| `gray0` | `textDark` |
| `gray5` | `textLight` |
| `gray75` | `textLighter` |
| `grayA` | `textDisable` / `textPlaceholder` |
| `grayD` | `lineBlock` |
| `grayE` | `lineDefault` |
| `grayF` (bg) | `backgroundSectionDefault` |
| `grayF` (fg) | `textBright` |
| `pinksMain` | `highlightDefault` |

## Text style mapping reference

| Legacy | Token |
|--------|-------|
| `labelRegular` / `labelBold` | `small` / `smallBold` |
| `bodyRegular` / `bodyBold` | `normal` / `normalBold` |
| `titleBold` | `bigBold` |

## Verification

- `grep -n "OTLColor\." <file>` → 0 matches (all 7 files)
- `grep -n "bodyRegular\|bodyBold\|..." <file>` → 0 matches (all 7 files)
- `grep -n "Color(0x" <file>` → 0 matches (all 7 files)
- `grep -n "context_ext.dart" <file>` → 1 match per file
- `dart format --set-exit-if-changed` → 0 changes