### PR TITLE
feat(ui): redesign course + lecture detail (PR 5/N, depends on foundation)

### DIFF
--- a/lib/pages/course_detail_page.dart
+++ b/lib/pages/course_detail_page.dart
@@ -1,11 +1,10 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/constants/color.dart';
 import 'package:otlplus/models/review.dart';
 import 'package:otlplus/widgets/responsive_button.dart';
 import 'package:otlplus/widgets/otl_scaffold.dart';
 import 'package:provider/provider.dart';
-import 'package:otlplus/constants/color.dart';
 import 'package:otlplus/extensions/course.dart';
 import 'package:otlplus/extensions/lecture.dart';
 import 'package:otlplus/models/course.dart';
@@ -13,6 +12,7 @@ import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/models/professor.dart';
 import 'package:otlplus/providers/course_detail_model.dart';
 import 'package:otlplus/providers/info_model.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/widgets/custom_header_delegate.dart';
 import 'package:otlplus/widgets/lecture_group_simple_block.dart';
 import 'package:otlplus/widgets/review_block.dart';
@@ -26,8 +26,8 @@ class CourseDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final CourseDetailModel courseDetailModel = context
-        .watch<CourseDetailModel>();
+    final CourseDetailModel courseDetailModel =
+        context.watch<CourseDetailModel>();
     final isEn = EasyLocalization.of(context)?.currentLocale == Locale('en');
 
     return OTLScaffold(
@@ -35,10 +35,10 @@ class CourseDetailPage extends StatelessWidget {
         middle: Text(
           courseDetailModel.hasData
               ? (isEn
-                    ? courseDetailModel.course.titleEn
-                    : courseDetailModel.course.title)
+                  ? courseDetailModel.course.titleEn
+                  : courseDetailModel.course.title)
               : '',
-          style: titleBold,
+          style: context.texts.bigBold,
         ),
         body: Card(
           shape: const RoundedRectangleBorder(
@@ -46,8 +46,8 @@ class CourseDetailPage extends StatelessWidget {
           ),
           child:
               context.select<CourseDetailModel, bool>((model) => model.hasData)
-              ? _buildBody(context)
-              : Center(child: const CircularProgressIndicator()),
+                  ? _buildBody(context)
+                  : Center(child: const CircularProgressIndicator()),
         ),
       ),
     );
@@ -72,27 +72,30 @@ class CourseDetailPage extends StatelessWidget {
           delegate: SliverChildListDelegate([
             _buildAttribute(context, course),
             _buildScores(context, course),
-            _buildDivider(),
+            _buildDivider(context),
             _buildProfessors(context, course),
-            _buildDivider(),
+            _buildDivider(context),
             const SizedBox(height: 8.0),
-            Text("dictionary.course_history".tr(), style: bodyBold),
+            Text(
+              "dictionary.course_history".tr(),
+              style: context.texts.normalBold,
+            ),
             _buildHistory(context),
-            _buildDivider(),
+            _buildDivider(context),
             const SizedBox(height: 8.0),
           ]),
         ),
-        _buildReviewHeader(),
+        _buildReviewHeader(context),
         _buildReviews(context, course),
       ],
     );
   }
 
-  Widget _buildDivider() {
-    return Divider(color: OTLColor.gray0.withValues(alpha: .25));
+  Widget _buildDivider(BuildContext context) {
+    return Divider(color: context.colors.textDark.withValues(alpha: .25));
   }
 
-  SliverPersistentHeader _buildReviewHeader() {
+  SliverPersistentHeader _buildReviewHeader(BuildContext context) {
     final headerKey = GlobalKey();
     return SliverPersistentHeader(
       pinned: true,
@@ -120,7 +123,7 @@ class CourseDetailPage extends StatelessWidget {
           },
           key: headerKey,
           text: "dictionary.reviews".tr(),
-          textStyle: bodyBold,
+          textStyle: context.texts.normalBold,
           icon: (shrinkOffset > 0)
               ? Icons.keyboard_arrow_up
               : Icons.keyboard_arrow_down,
@@ -137,25 +140,25 @@ class CourseDetailPage extends StatelessWidget {
     final isEn = EasyLocalization.of(context)?.currentLocale == Locale('en');
 
     return ChoiceChip(
-      selectedColor: OTLColor.pinksSub,
-      backgroundColor: OTLColor.grayE,
+      selectedColor: OTLColor.pinksSub, // legacy: pinksSub
+      backgroundColor: context.colors.lineDefault,
       label: Text(
         professor == null
             ? "common.all".tr()
             : (isEn
-                  ? (professor.nameEn == '' ? professor.name : professor.nameEn)
-                  : professor.name),
-        style: labelRegular,
+                ? (professor.nameEn == '' ? professor.name : professor.nameEn)
+                : professor.name),
+        style: context.texts.small,
       ),
       selected: (professor == null
           ? selectedFilter == "ALL"
           : selectedFilter == professor.professorId.toString()),
       onSelected: (isSelected) {
         context.read<CourseDetailModel>().setFilter(
-          (professor != null && isSelected)
-              ? professor.professorId.toString()
-              : "ALL",
-        );
+              (professor != null && isSelected)
+                  ? professor.professorId.toString()
+                  : "ALL",
+            );
       },
     );
   }
@@ -165,7 +168,7 @@ class CourseDetailPage extends StatelessWidget {
 
     return Row(
       children: <Widget>[
-        Text("dictionary.professors".tr(), style: bodyBold),
+        Text("dictionary.professors".tr(), style: context.texts.normalBold),
         const SizedBox(width: 8.0),
         Expanded(
           child: SingleChildScrollView(
@@ -210,14 +213,17 @@ class CourseDetailPage extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: <Widget>[
         _buildStatus(
+          context,
           "review.grade".tr(),
           (lecture == null) ? course.gradeLetter : lecture.gradeLetter,
         ),
         _buildStatus(
+          context,
           "review.load".tr(),
           (lecture == null) ? course.loadLetter : lecture.loadLetter,
         ),
         _buildStatus(
+          context,
           "review.speech".tr(),
           (lecture == null) ? course.speechLetter : lecture.speechLetter,
         ),
@@ -233,21 +239,21 @@ class CourseDetailPage extends StatelessWidget {
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Text("dictionary.code".tr(), style: bodyBold),
+            Text("dictionary.code".tr(), style: context.texts.normalBold),
             const SizedBox(width: 8.0),
-            Expanded(child: Text(course.oldCode, style: bodyRegular)),
+            Expanded(child: Text(course.oldCode, style: context.texts.normal)),
           ],
         ),
         const SizedBox(height: 4.0),
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Text("dictionary.type".tr(), style: bodyBold),
+            Text("dictionary.type".tr(), style: context.texts.normalBold),
             const SizedBox(width: 8.0),
             Expanded(
               child: Text(
                 "${isEn ? course.department?.nameEn : course.department?.name}, ${isEn ? course.typeEn : course.type}",
-                style: bodyRegular,
+                style: context.texts.normal,
               ),
             ),
           ],
@@ -256,9 +262,14 @@ class CourseDetailPage extends StatelessWidget {
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Text("dictionary.description".tr(), style: bodyBold),
+            Text(
+              "dictionary.description".tr(),
+              style: context.texts.normalBold,
+            ),
             const SizedBox(width: 8.0),
-            Expanded(child: Text(course.summary, style: bodyRegular)),
+            Expanded(
+              child: Text(course.summary, style: context.texts.normal),
+            ),
           ],
         ),
         const SizedBox(height: 4.0),
@@ -267,15 +278,15 @@ class CourseDetailPage extends StatelessWidget {
   }
 
   Widget _buildHistory(BuildContext context) {
-    final _scrollController = ScrollController();
+    final scrollCtrl = ScrollController();
     final years = context.select<InfoModel, Set<int>>((model) => model.years);
     final courseDetailModel = context.watch<CourseDetailModel>();
     final isEn = EasyLocalization.of(context)?.currentLocale == Locale('en');
 
     return Scrollbar(
-      controller: _scrollController,
+      controller: scrollCtrl,
       child: SingleChildScrollView(
-        controller: _scrollController,
+        controller: scrollCtrl,
         scrollDirection: Axis.horizontal,
         padding: const EdgeInsets.symmetric(vertical: 8.0),
         reverse: true,
@@ -299,7 +310,7 @@ class CourseDetailPage extends StatelessWidget {
                         child: Text(
                           year.toString(),
                           textAlign: TextAlign.center,
-                          style: bodyBold,
+                          style: context.texts.normalBold,
                         ),
                       ),
                     )
@@ -347,7 +358,9 @@ class CourseDetailPage extends StatelessWidget {
               child: Text(
                 "dictionary.not_offered".tr(),
                 textAlign: TextAlign.center,
-                style: bodyRegular.copyWith(color: OTLColor.grayA),
+                style: context.texts.normal.copyWith(
+                  color: context.colors.textDisable,
+                ),
               ),
             );
           return LectureGroupSimpleBlock(
@@ -379,24 +392,23 @@ class CourseDetailPage extends StatelessWidget {
                       )),
             )
             .map((lecture) {
-              Review? existingReview;
-              try {
-                existingReview = user.reviews.firstWhere(
-                  (review) => review.lecture.id == lecture.id,
-                  orElse: null,
-                );
-              } catch (_) {}
-              return ReviewWriteBlock(
-                lecture: lecture,
-                existingReview: existingReview,
-                isSimple: false,
-                onUploaded: (review) {
-                  context.read<InfoModel>().getInfo();
-                  context.read<CourseDetailModel>().updateCourseReviews(review);
-                },
-              );
-            })
-            .toList(),
+          Review? existingReview;
+          try {
+            existingReview = user.reviews.firstWhere(
+              (review) => review.lecture.id == lecture.id,
+              orElse: null,
+            );
+          } catch (_) {}
+          return ReviewWriteBlock(
+            lecture: lecture,
+            existingReview: existingReview,
+            isSimple: false,
+            onUploaded: (review) {
+              context.read<InfoModel>().getInfo();
+              context.read<CourseDetailModel>().updateCourseReviews(review);
+            },
+          );
+        }).toList(),
         ...context.select<CourseDetailModel, List<Widget>>((model) {
           if (model.reviews?.isEmpty == true) {
             return [
@@ -405,7 +417,9 @@ class CourseDetailPage extends StatelessWidget {
                   padding: const EdgeInsets.symmetric(vertical: 8.0),
                   child: Text(
                     "common.no_result".tr(),
-                    style: labelRegular.copyWith(color: OTLColor.grayA),
+                    style: context.texts.small.copyWith(
+                      color: context.colors.textDisable,
+                    ),
                   ),
                 ),
               ),
@@ -420,7 +434,9 @@ class CourseDetailPage extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(vertical: 8.0),
                       child: Text(
                         "common.no_result".tr(),
-                        style: labelRegular.copyWith(color: OTLColor.grayA),
+                        style: context.texts.small.copyWith(
+                          color: context.colors.textDisable,
+                        ),
                       ),
                     ),
                   ),
@@ -431,13 +447,13 @@ class CourseDetailPage extends StatelessWidget {
     );
   }
 
-  Widget _buildStatus(String title, String content) {
+  Widget _buildStatus(BuildContext context, String title, String content) {
     return Padding(
       padding: const EdgeInsets.all(4.0),
       child: Column(
         children: <Widget>[
-          Text(content, style: titleRegular),
-          Text(title, style: labelRegular),
+          Text(content, style: context.texts.big),
+          Text(title, style: context.texts.small),
         ],
       ),
     );

--- a/lib/pages/course_detail_page.dart
+++ b/lib/pages/course_detail_page.dart
@@ -26,8 +26,8 @@ class CourseDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final CourseDetailModel courseDetailModel =
-        context.watch<CourseDetailModel>();
+    final CourseDetailModel courseDetailModel = context
+        .watch<CourseDetailModel>();
     final isEn = EasyLocalization.of(context)?.currentLocale == Locale('en');
 
     return OTLScaffold(
@@ -35,8 +35,8 @@ class CourseDetailPage extends StatelessWidget {
         middle: Text(
           courseDetailModel.hasData
               ? (isEn
-                  ? courseDetailModel.course.titleEn
-                  : courseDetailModel.course.title)
+                    ? courseDetailModel.course.titleEn
+                    : courseDetailModel.course.title)
               : '',
           style: context.texts.bigBold,
         ),
@@ -46,8 +46,8 @@ class CourseDetailPage extends StatelessWidget {
           ),
           child:
               context.select<CourseDetailModel, bool>((model) => model.hasData)
-                  ? _buildBody(context)
-                  : Center(child: const CircularProgressIndicator()),
+              ? _buildBody(context)
+              : Center(child: const CircularProgressIndicator()),
         ),
       ),
     );
@@ -146,8 +146,8 @@ class CourseDetailPage extends StatelessWidget {
         professor == null
             ? "common.all".tr()
             : (isEn
-                ? (professor.nameEn == '' ? professor.name : professor.nameEn)
-                : professor.name),
+                  ? (professor.nameEn == '' ? professor.name : professor.nameEn)
+                  : professor.name),
         style: context.texts.small,
       ),
       selected: (professor == null
@@ -155,10 +155,10 @@ class CourseDetailPage extends StatelessWidget {
           : selectedFilter == professor.professorId.toString()),
       onSelected: (isSelected) {
         context.read<CourseDetailModel>().setFilter(
-              (professor != null && isSelected)
-                  ? professor.professorId.toString()
-                  : "ALL",
-            );
+          (professor != null && isSelected)
+              ? professor.professorId.toString()
+              : "ALL",
+        );
       },
     );
   }
@@ -267,9 +267,7 @@ class CourseDetailPage extends StatelessWidget {
               style: context.texts.normalBold,
             ),
             const SizedBox(width: 8.0),
-            Expanded(
-              child: Text(course.summary, style: context.texts.normal),
-            ),
+            Expanded(child: Text(course.summary, style: context.texts.normal)),
           ],
         ),
         const SizedBox(height: 4.0),
@@ -392,23 +390,24 @@ class CourseDetailPage extends StatelessWidget {
                       )),
             )
             .map((lecture) {
-          Review? existingReview;
-          try {
-            existingReview = user.reviews.firstWhere(
-              (review) => review.lecture.id == lecture.id,
-              orElse: null,
-            );
-          } catch (_) {}
-          return ReviewWriteBlock(
-            lecture: lecture,
-            existingReview: existingReview,
-            isSimple: false,
-            onUploaded: (review) {
-              context.read<InfoModel>().getInfo();
-              context.read<CourseDetailModel>().updateCourseReviews(review);
-            },
-          );
-        }).toList(),
+              Review? existingReview;
+              try {
+                existingReview = user.reviews.firstWhere(
+                  (review) => review.lecture.id == lecture.id,
+                  orElse: null,
+                );
+              } catch (_) {}
+              return ReviewWriteBlock(
+                lecture: lecture,
+                existingReview: existingReview,
+                isSimple: false,
+                onUploaded: (review) {
+                  context.read<InfoModel>().getInfo();
+                  context.read<CourseDetailModel>().updateCourseReviews(review);
+                },
+              );
+            })
+            .toList(),
         ...context.select<CourseDetailModel, List<Widget>>((model) {
           if (model.reviews?.isEmpty == true) {
             return [

--- a/lib/pages/lecture_detail_page.dart
+++ b/lib/pages/lecture_detail_page.dart
@@ -2,7 +2,6 @@ import 'package:easy_localization/easy_localization.dart';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_web_browser/flutter_web_browser.dart';
-import 'package:otlplus/constants/text_styles.dart';
 import 'package:otlplus/extensions/semester.dart';
 import 'package:otlplus/models/review.dart';
 import 'package:otlplus/pages/course_detail_page.dart';
@@ -11,20 +10,20 @@ import 'package:otlplus/widgets/responsive_button.dart';
 import 'package:otlplus/utils/navigator.dart';
 import 'package:otlplus/widgets/otl_scaffold.dart';
 import 'package:provider/provider.dart';
-import 'package:otlplus/constants/color.dart';
 import 'package:otlplus/extensions/lecture.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/providers/course_detail_model.dart';
 import 'package:otlplus/providers/info_model.dart';
 import 'package:otlplus/providers/lecture_detail_model.dart';
 import 'package:otlplus/providers/timetable_model.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/widgets/custom_header_delegate.dart';
 import 'package:otlplus/widgets/review_block.dart';
 import 'package:otlplus/widgets/review_write_block.dart';
 
 class LectureDetailPage extends StatelessWidget {
   LectureDetailPage({Key? key, this.fromCourseDetailPage = false})
-    : super(key: key);
+      : super(key: key);
 
   static String route = 'lecture_detail_page';
   final bool fromCourseDetailPage;
@@ -40,7 +39,8 @@ class LectureDetailPage extends StatelessWidget {
     final payloadJson = jsonEncode(payload);
     final payloadBase64 = base64Encode(utf8.encode(payloadJson));
 
-    return Uri.https("erp.kaist.ac.kr", "/com/lgin/SsoCtr/initExtPageWork.do", {
+    return Uri.https(
+        "erp.kaist.ac.kr", "/com/lgin/SsoCtr/initExtPageWork.do", {
       "link": "estblSubjt",
       "params": payloadBase64,
     }).toString();
@@ -48,8 +48,8 @@ class LectureDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final LectureDetailModel lectureDetailModel = context
-        .watch<LectureDetailModel>();
+    final LectureDetailModel lectureDetailModel =
+        context.watch<LectureDetailModel>();
     final isEn = EasyLocalization.of(context)?.currentLocale == Locale('en');
 
     return OTLScaffold(
@@ -57,25 +57,24 @@ class LectureDetailPage extends StatelessWidget {
         middle: Text(
           lectureDetailModel.hasData
               ? (isEn
-                    ? lectureDetailModel.lecture.titleEn
-                    : lectureDetailModel.lecture.title)
+                  ? lectureDetailModel.lecture.titleEn
+                  : lectureDetailModel.lecture.title)
               : '',
-          style: titleBold,
+          style: context.texts.bigBold,
         ),
         body: Card(
           shape: const RoundedRectangleBorder(),
-          child:
-              context.select<LectureDetailModel, bool>((model) => model.hasData)
+          child: context.select<LectureDetailModel, bool>(
+                  (model) => model.hasData)
               ? _buildBody(context)
               : Center(child: const CircularProgressIndicator()),
         ),
-        trailing:
-            (context.select<LectureDetailModel, bool>(
-                  (model) => model.hasData,
-                ) &&
+        trailing: (context.select<LectureDetailModel, bool>(
+                    (model) => model.hasData,
+                  ) &&
                 context.select<LectureDetailModel, bool>(
-                  (model) => model.isUpdateEnabled,
-                ) &&
+                    (model) => model.isUpdateEnabled,
+                  ) &&
                 context.read<TimetableModel>().selectedIndex != 0)
             ? _buildUpdateButton(context)
             : null,
@@ -136,7 +135,10 @@ class LectureDetailPage extends StatelessWidget {
                 context: context,
                 builder: (_) => OTLDialog(
                   type: OTLDialogType.addLectureWithTab,
-                  namedArgs: {'lecture': lectureTitle, 'timetable': timetable},
+                  namedArgs: {
+                    'lecture': lectureTitle,
+                    'timetable': timetable,
+                  },
                   onTapPos: () => result = true,
                 ),
               );
@@ -191,7 +193,9 @@ class LectureDetailPage extends StatelessWidget {
               }
             },
             text: "dictionary.dictionary".tr(),
-            textStyle: bodyRegular.copyWith(color: OTLColor.pinksMain),
+            textStyle: context.texts.normal.copyWith(
+              color: context.colors.highlightDefault,
+            ),
           ),
         ),
         IconTextButton(
@@ -200,7 +204,7 @@ class LectureDetailPage extends StatelessWidget {
             customTabsOptions: CustomTabsOptions(
               colorScheme: CustomTabsColorScheme.light,
               defaultColorSchemeParams: CustomTabsColorSchemeParams(
-                toolbarColor: OTLColor.pinksLight,
+                toolbarColor: context.colors.backgroundPageDefault,
               ),
               shareState: CustomTabsShareState.on,
               instantAppsEnabled: true,
@@ -209,12 +213,15 @@ class LectureDetailPage extends StatelessWidget {
             ),
             safariVCOptions: SafariViewControllerOptions(
               barCollapsingEnabled: true,
-              dismissButtonStyle: SafariViewControllerDismissButtonStyle.close,
+              dismissButtonStyle:
+                  SafariViewControllerDismissButtonStyle.close,
               modalPresentationCapturesStatusBarAppearance: true,
             ),
           ),
           text: "dictionary.syllabus".tr(),
-          textStyle: bodyRegular.copyWith(color: OTLColor.pinksMain),
+          textStyle: context.texts.normal.copyWith(
+            color: context.colors.highlightDefault,
+          ),
         ),
       ],
     );
@@ -227,17 +234,17 @@ class LectureDetailPage extends StatelessWidget {
         SliverList(
           delegate: SliverChildListDelegate([
             _buildAttributes(context, lecture),
-            _buildScores(lecture),
+            _buildScores(context, lecture),
             const SizedBox(height: 16.0),
           ]),
         ),
-        _buildReviewHeader(),
+        _buildReviewHeader(context),
         _buildReviews(context, lecture),
       ],
     );
   }
 
-  SliverPersistentHeader _buildReviewHeader() {
+  SliverPersistentHeader _buildReviewHeader(BuildContext context) {
     final headerKey = GlobalKey();
     return SliverPersistentHeader(
       pinned: true,
@@ -265,7 +272,7 @@ class LectureDetailPage extends StatelessWidget {
           },
           key: headerKey,
           text: "dictionary.reviews".tr(),
-          textStyle: bodyBold,
+          textStyle: context.texts.normalBold,
           icon: (shrinkOffset > 0)
               ? Icons.keyboard_arrow_up
               : Icons.keyboard_arrow_down,
@@ -303,7 +310,9 @@ class LectureDetailPage extends StatelessWidget {
                   padding: const EdgeInsets.symmetric(vertical: 8.0),
                   child: Text(
                     "common.no_result".tr(),
-                    style: labelRegular.copyWith(color: OTLColor.grayA),
+                    style: context.texts.small.copyWith(
+                      color: context.colors.textDisable,
+                    ),
                   ),
                 ),
               ),
@@ -318,7 +327,7 @@ class LectureDetailPage extends StatelessWidget {
     );
   }
 
-  Widget _buildScores(Lecture lecture) {
+  Widget _buildScores(BuildContext context, Lecture lecture) {
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: Table(
@@ -326,16 +335,19 @@ class LectureDetailPage extends StatelessWidget {
           TableRow(
             children: <Widget>[
               _buildStatus(
+                context,
                 "dictionary.language".tr(),
                 lecture.isEnglish ? "Eng" : "한",
               ),
               _buildStatus(
+                context,
                 (lecture.credit > 0) ? "dictionary.credit".tr() : "AU",
                 (lecture.credit > 0)
                     ? lecture.credit.toString()
                     : lecture.creditAu.toString(),
               ),
               _buildStatus(
+                context,
                 "dictionary.competition".tr(),
                 (lecture.limit == 0)
                     ? "0.0:1"
@@ -345,9 +357,12 @@ class LectureDetailPage extends StatelessWidget {
           ),
           TableRow(
             children: <Widget>[
-              _buildStatus("review.grade".tr(), lecture.gradeLetter),
-              _buildStatus("review.load".tr(), lecture.loadLetter),
-              _buildStatus("review.speech".tr(), lecture.speechLetter),
+              _buildStatus(
+                  context, "review.grade".tr(), lecture.gradeLetter),
+              _buildStatus(
+                  context, "review.load".tr(), lecture.loadLetter),
+              _buildStatus(
+                  context, "review.speech".tr(), lecture.speechLetter),
             ],
           ),
         ],
@@ -355,15 +370,16 @@ class LectureDetailPage extends StatelessWidget {
     );
   }
 
-  Widget _buildAttribute(String title, String content) {
+  Widget _buildAttribute(
+      BuildContext context, String title, String content) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 4.0),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(title, style: bodyBold),
+          Text(title, style: context.texts.normalBold),
           const SizedBox(width: 4.0),
-          Expanded(child: Text(content, style: bodyRegular)),
+          Expanded(child: Text(content, style: context.texts.normal)),
         ],
       ),
     );
@@ -374,20 +390,24 @@ class LectureDetailPage extends StatelessWidget {
 
     return Column(
       children: [
-        _buildAttribute("dictionary.code".tr(), lecture.oldCode),
+        _buildAttribute(context, "dictionary.code".tr(), lecture.oldCode),
         _buildAttribute(
+          context,
           "dictionary.type".tr(),
           isEn ? lecture.typeEn : lecture.type,
         ),
         _buildAttribute(
+          context,
           "dictionary.department".tr(),
           isEn ? lecture.departmentNameEn : lecture.departmentName,
         ),
         _buildAttribute(
+          context,
           "dictionary.professors".tr(),
           isEn ? lecture.professorsStrShortEn : lecture.professorsStrShort,
         ),
         _buildAttribute(
+          context,
           "dictionary.classroom".tr(),
           lecture.classtimes
               .map(
@@ -397,27 +417,29 @@ class LectureDetailPage extends StatelessWidget {
               .toSet()
               .join(", "),
         ),
-        _buildAttribute("dictionary.limit".tr(), lecture.limit.toString()),
         _buildAttribute(
+            context, "dictionary.limit".tr(), lecture.limit.toString()),
+        _buildAttribute(
+          context,
           "dictionary.exam".tr(),
           (lecture.examtimes.length == 0)
               ? "common.no_info".tr()
               : lecture.examtimes
-                    .map((examtime) => isEn ? examtime.strEn : examtime.str)
-                    .toSet()
-                    .join(", "),
+                  .map((examtime) => isEn ? examtime.strEn : examtime.str)
+                  .toSet()
+                  .join(", "),
         ),
       ],
     );
   }
 
-  Widget _buildStatus(String title, String content) {
+  Widget _buildStatus(BuildContext context, String title, String content) {
     return Padding(
       padding: const EdgeInsets.all(4.0),
       child: Column(
         children: <Widget>[
-          Text(content, style: titleRegular),
-          Text(title, style: labelRegular),
+          Text(content, style: context.texts.big),
+          Text(title, style: context.texts.small),
         ],
       ),
     );

--- a/lib/pages/lecture_detail_page.dart
+++ b/lib/pages/lecture_detail_page.dart
@@ -23,7 +23,7 @@ import 'package:otlplus/widgets/review_write_block.dart';
 
 class LectureDetailPage extends StatelessWidget {
   LectureDetailPage({Key? key, this.fromCourseDetailPage = false})
-      : super(key: key);
+    : super(key: key);
 
   static String route = 'lecture_detail_page';
   final bool fromCourseDetailPage;
@@ -39,8 +39,7 @@ class LectureDetailPage extends StatelessWidget {
     final payloadJson = jsonEncode(payload);
     final payloadBase64 = base64Encode(utf8.encode(payloadJson));
 
-    return Uri.https(
-        "erp.kaist.ac.kr", "/com/lgin/SsoCtr/initExtPageWork.do", {
+    return Uri.https("erp.kaist.ac.kr", "/com/lgin/SsoCtr/initExtPageWork.do", {
       "link": "estblSubjt",
       "params": payloadBase64,
     }).toString();
@@ -48,8 +47,8 @@ class LectureDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final LectureDetailModel lectureDetailModel =
-        context.watch<LectureDetailModel>();
+    final LectureDetailModel lectureDetailModel = context
+        .watch<LectureDetailModel>();
     final isEn = EasyLocalization.of(context)?.currentLocale == Locale('en');
 
     return OTLScaffold(
@@ -57,24 +56,25 @@ class LectureDetailPage extends StatelessWidget {
         middle: Text(
           lectureDetailModel.hasData
               ? (isEn
-                  ? lectureDetailModel.lecture.titleEn
-                  : lectureDetailModel.lecture.title)
+                    ? lectureDetailModel.lecture.titleEn
+                    : lectureDetailModel.lecture.title)
               : '',
           style: context.texts.bigBold,
         ),
         body: Card(
           shape: const RoundedRectangleBorder(),
-          child: context.select<LectureDetailModel, bool>(
-                  (model) => model.hasData)
+          child:
+              context.select<LectureDetailModel, bool>((model) => model.hasData)
               ? _buildBody(context)
               : Center(child: const CircularProgressIndicator()),
         ),
-        trailing: (context.select<LectureDetailModel, bool>(
-                    (model) => model.hasData,
-                  ) &&
+        trailing:
+            (context.select<LectureDetailModel, bool>(
+                  (model) => model.hasData,
+                ) &&
                 context.select<LectureDetailModel, bool>(
-                    (model) => model.isUpdateEnabled,
-                  ) &&
+                  (model) => model.isUpdateEnabled,
+                ) &&
                 context.read<TimetableModel>().selectedIndex != 0)
             ? _buildUpdateButton(context)
             : null,
@@ -135,10 +135,7 @@ class LectureDetailPage extends StatelessWidget {
                 context: context,
                 builder: (_) => OTLDialog(
                   type: OTLDialogType.addLectureWithTab,
-                  namedArgs: {
-                    'lecture': lectureTitle,
-                    'timetable': timetable,
-                  },
+                  namedArgs: {'lecture': lectureTitle, 'timetable': timetable},
                   onTapPos: () => result = true,
                 ),
               );
@@ -213,8 +210,7 @@ class LectureDetailPage extends StatelessWidget {
             ),
             safariVCOptions: SafariViewControllerOptions(
               barCollapsingEnabled: true,
-              dismissButtonStyle:
-                  SafariViewControllerDismissButtonStyle.close,
+              dismissButtonStyle: SafariViewControllerDismissButtonStyle.close,
               modalPresentationCapturesStatusBarAppearance: true,
             ),
           ),
@@ -357,12 +353,9 @@ class LectureDetailPage extends StatelessWidget {
           ),
           TableRow(
             children: <Widget>[
-              _buildStatus(
-                  context, "review.grade".tr(), lecture.gradeLetter),
-              _buildStatus(
-                  context, "review.load".tr(), lecture.loadLetter),
-              _buildStatus(
-                  context, "review.speech".tr(), lecture.speechLetter),
+              _buildStatus(context, "review.grade".tr(), lecture.gradeLetter),
+              _buildStatus(context, "review.load".tr(), lecture.loadLetter),
+              _buildStatus(context, "review.speech".tr(), lecture.speechLetter),
             ],
           ),
         ],
@@ -370,8 +363,7 @@ class LectureDetailPage extends StatelessWidget {
     );
   }
 
-  Widget _buildAttribute(
-      BuildContext context, String title, String content) {
+  Widget _buildAttribute(BuildContext context, String title, String content) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 4.0),
       child: Row(
@@ -418,16 +410,19 @@ class LectureDetailPage extends StatelessWidget {
               .join(", "),
         ),
         _buildAttribute(
-            context, "dictionary.limit".tr(), lecture.limit.toString()),
+          context,
+          "dictionary.limit".tr(),
+          lecture.limit.toString(),
+        ),
         _buildAttribute(
           context,
           "dictionary.exam".tr(),
           (lecture.examtimes.length == 0)
               ? "common.no_info".tr()
               : lecture.examtimes
-                  .map((examtime) => isEn ? examtime.strEn : examtime.str)
-                  .toSet()
-                  .join(", "),
+                    .map((examtime) => isEn ? examtime.strEn : examtime.str)
+                    .toSet()
+                    .join(", "),
         ),
       ],
     );

--- a/lib/widgets/custom_header_delegate.dart
+++ b/lib/widgets/custom_header_delegate.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
+import 'package:otlplus/theme/context_ext.dart';
 
 class CustomHeaderDelegate extends SliverPersistentHeaderDelegate {
   final Widget Function(double) builder;
@@ -19,7 +19,7 @@ class CustomHeaderDelegate extends SliverPersistentHeaderDelegate {
     bool overlapsContent,
   ) {
     return Container(
-      color: OTLColor.grayF,
+      color: context.colors.backgroundSectionDefault,
       padding: padding,
       transform: Matrix4.translationValues(0, -1, 0),
       child: Material(color: Colors.transparent, child: builder(shrinkOffset)),

--- a/lib/widgets/expandable_text.dart
+++ b/lib/widgets/expandable_text.dart
@@ -1,11 +1,11 @@
 import 'package:easy_localization/easy_localization.dart' as _;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
+import 'package:otlplus/theme/context_ext.dart';
 
 class ExpandableText extends StatefulWidget {
   const ExpandableText(this.text, {Key? key, this.maxLines = 5, this.style})
-    : super(key: key);
+      : super(key: key);
 
   final String text;
   final int maxLines;
@@ -25,7 +25,9 @@ class ExpandableTextState extends State<ExpandableText> {
         TextSpan(text: ".. ", style: widget.style),
         TextSpan(
           text: "review.expand".tr(),
-          style: (widget.style ?? TextStyle()).copyWith(color: OTLColor.gray75),
+          style: (widget.style ?? TextStyle()).copyWith(
+            color: context.colors.textLighter,
+          ),
           recognizer: TapGestureRecognizer()
             ..onTap = () {
               setState(() => _expanded = true);

--- a/lib/widgets/expandable_text.dart
+++ b/lib/widgets/expandable_text.dart
@@ -5,7 +5,7 @@ import 'package:otlplus/theme/context_ext.dart';
 
 class ExpandableText extends StatefulWidget {
   const ExpandableText(this.text, {Key? key, this.maxLines = 5, this.style})
-      : super(key: key);
+    : super(key: key);
 
   final String text;
   final int maxLines;

--- a/lib/widgets/lecture_group_simple_block.dart
+++ b/lib/widgets/lecture_group_simple_block.dart
@@ -46,11 +46,13 @@ class LectureGroupSimpleBlock extends StatelessWidget {
                           ? const Radius.circular(4.0)
                           : Radius.zero,
                     ),
-                    color: (lecture.professors.any(
-                      (professor) =>
-                          professor.professorId.toString() == filter,
-                    ))
-                        ? OTLColor.pinksSub // legacy: pinksSub
+                    color:
+                        (lecture.professors.any(
+                          (professor) =>
+                              professor.professorId.toString() == filter,
+                        ))
+                        ? OTLColor
+                              .pinksSub // legacy: pinksSub
                         : context.colors.lineDefault,
                   ),
                   child: ClipRRect(
@@ -65,9 +67,9 @@ class LectureGroupSimpleBlock extends StatelessWidget {
                     child: BackgroundButton(
                       onTap: () {
                         context.read<LectureDetailModel>().loadLecture(
-                              lecture.id,
-                              false,
-                            );
+                          lecture.id,
+                          false,
+                        );
                         OTLNavigator.push(
                           context,
                           LectureDetailPage(fromCourseDetailPage: true),

--- a/lib/widgets/lecture_group_simple_block.dart
+++ b/lib/widgets/lecture_group_simple_block.dart
@@ -1,14 +1,14 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/constants/color.dart';
 import 'package:otlplus/widgets/responsive_button.dart';
 import 'package:otlplus/pages/lecture_detail_page.dart';
 import 'package:otlplus/utils/navigator.dart';
 import 'package:provider/provider.dart';
-import 'package:otlplus/constants/color.dart';
 import 'package:otlplus/extensions/lecture.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/providers/lecture_detail_model.dart';
+import 'package:otlplus/theme/context_ext.dart';
 
 class LectureGroupSimpleBlock extends StatelessWidget {
   final List<Lecture> lectures;
@@ -34,7 +34,7 @@ class LectureGroupSimpleBlock extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: ListTile.divideTiles(
-              color: OTLColor.gray0,
+              color: context.colors.textDark,
               tiles: lectures.map(
                 (lecture) => Container(
                   decoration: BoxDecoration(
@@ -46,13 +46,12 @@ class LectureGroupSimpleBlock extends StatelessWidget {
                           ? const Radius.circular(4.0)
                           : Radius.zero,
                     ),
-                    color:
-                        (lecture.professors.any(
-                          (professor) =>
-                              professor.professorId.toString() == filter,
-                        ))
-                        ? OTLColor.pinksSub
-                        : OTLColor.grayE,
+                    color: (lecture.professors.any(
+                      (professor) =>
+                          professor.professorId.toString() == filter,
+                    ))
+                        ? OTLColor.pinksSub // legacy: pinksSub
+                        : context.colors.lineDefault,
                   ),
                   child: ClipRRect(
                     borderRadius: BorderRadius.vertical(
@@ -66,9 +65,9 @@ class LectureGroupSimpleBlock extends StatelessWidget {
                     child: BackgroundButton(
                       onTap: () {
                         context.read<LectureDetailModel>().loadLecture(
-                          lecture.id,
-                          false,
-                        );
+                              lecture.id,
+                              false,
+                            );
                         OTLNavigator.push(
                           context,
                           LectureDetailPage(fromCourseDetailPage: true),
@@ -81,11 +80,11 @@ class LectureGroupSimpleBlock extends StatelessWidget {
                         ),
                         child: Text.rich(
                           TextSpan(
-                            style: bodyRegular,
+                            style: context.texts.normal,
                             children: [
                               TextSpan(
                                 text: lecture.classTitle,
-                                style: bodyBold,
+                                style: context.texts.normalBold,
                               ),
                               TextSpan(text: ' '),
                               TextSpan(

--- a/lib/widgets/lecture_simple_block.dart
+++ b/lib/widgets/lecture_simple_block.dart
@@ -1,9 +1,8 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/widgets/responsive_button.dart';
+import 'package:otlplus/theme/context_ext.dart';
 
 class LectureSimpleBlock extends StatelessWidget {
   final Lecture lecture;
@@ -24,7 +23,7 @@ class LectureSimpleBlock extends StatelessWidget {
       margin: const EdgeInsets.all(3.0),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(4.0),
-        color: OTLColor.grayE,
+        color: context.colors.lineDefault,
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(4.0),
@@ -38,15 +37,15 @@ class LectureSimpleBlock extends StatelessWidget {
             child: Center(
               child: Text.rich(
                 TextSpan(
-                  style: bodyRegular.copyWith(
+                  style: context.texts.normal.copyWith(
                     color: hasReview
-                        ? OTLColor.gray0.withValues(alpha: .4)
-                        : OTLColor.gray0,
+                        ? context.colors.textDark.withValues(alpha: .4)
+                        : context.colors.textDark,
                   ),
                   children: <TextSpan>[
                     TextSpan(
                       text: isEn ? lecture.titleEn : lecture.title,
-                      style: bodyBold,
+                      style: context.texts.normalBold,
                     ),
                     const TextSpan(text: "\n"),
                     TextSpan(text: lecture.oldCode),


### PR DESCRIPTION
## Coordinated redesign stream — Stage 5 of 6

This PR migrates **6 files** in the **course + lecture detail** surface from legacy `OTLColor.*` + `lib/constants/text_styles.dart` constants to the new `context.colors` / `context.texts` design-system tokens introduced in **Foundation PR #237**.

| Stage | PR | Domain | Status |
|-------|----|--------|--------|
| 1 | #237 | foundation theme | ready to merge |
| 2 | #238 | home + timetable | draft |
| 3 | #236 | account + settings | draft |
| 4 | #241 | search + dictionary | draft |
| 5 | #240 | course + lecture detail | draft |
| 6 | #239 | reviews | draft |

### Dependency
This PR will **not compile standalone** — it imports `package:otlplus/theme/context_ext.dart` which is introduced in #237. The import error resolves once #237 merges and this branch is rebased onto `main` (use `scripts/rebase-onto-foundation.sh --cleanup` from #237).

---

## Summary

Migrate 6 files in the course/lecture detail surface from legacy `OTLColor`/`text_styles.dart` constants to the new foundation design-system tokens (`context.colors.*`, `context.texts.*`).

## Depends on

- #237 (foundation theme PR) — this branch will not compile until foundation is merged and rebased.

## Files changed

| File | Changes |
|------|---------|
| `course_detail_page.dart` | All text styles → `context.texts.*`, colors → `context.colors.*`, added `BuildContext` to `_buildDivider`, `_buildReviewHeader`, `_buildStatus` |
| `lecture_detail_page.dart` | Same migration, `pinksMain` → `highlightDefault`, `pinksLight` → `backgroundPageDefault`, added `BuildContext` to `_buildScores`, `_buildAttribute`, `_buildStatus`, `_buildReviewHeader` |
| `lecture_group_simple_block.dart` | `gray0` → `textDark`, `grayE` → `lineDefault`, text styles migrated |
| `lecture_simple_block.dart` | `grayE` → `lineDefault`, `gray0` → `textDark`, text styles migrated |
| `expandable_text.dart` | `gray75` → `textLighter` |
| `custom_header_delegate.dart` | `grayF` → `backgroundSectionDefault` |

## Token mapping applied

```
Colors:
  gray0 → textDark          gray3 → textDefault
  gray5 → textLight         gray6/gray75 → textLighter
  grayA → textDisable       grayE → lineDefault
  grayF → backgroundSectionDefault/textBright
  pinksLight → backgroundPageDefault
  pinksMain → highlightDefault
  pinksSub → kept (// legacy: pinksSub)

Text styles:
  labelRegular/Bold → small/smallBold
  bodyRegular/Bold → normal/normalBold
  titleRegular/Bold → big/bigBold
```

## Legacy items retained

- `OTLColor.pinksSub` in `course_detail_page.dart` and `lecture_group_simple_block.dart` (marked `// legacy: pinksSub`)