### PR TITLE
feat(ui): redesign search + dictionary (PR 4/N, depends on foundation)

### DIFF
--- a/lib/pages/course_search_page.dart
+++ b/lib/pages/course_search_page.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/providers/course_search_model.dart';
 import 'package:otlplus/utils/navigator.dart';
 import 'package:otlplus/widgets/otl_scaffold.dart';
@@ -52,7 +51,7 @@ class _CourseSearchPageState extends State<CourseSearchPage> {
           padding: EdgeInsets.only(right: 16.0),
           child: SearchTextfield(
             autoFocus: _searchTextController.text == '' && widget.openKeyboard,
-            backgroundColor: OTLColor.grayF,
+            backgroundColor: context.colors.backgroundSectionDefault,
             textController: _searchTextController,
             focusNode: _focusNode,
           ),
@@ -87,10 +86,14 @@ class _CourseSearchPageState extends State<CourseSearchPage> {
                       },
                       child: Text(
                         "common.reset_all".tr(),
-                        style: bodyBold.copyWith(color: OTLColor.pinksMain),
+                        style: context.texts.normalBold.copyWith(
+                          color: context.colors.highlightDefault,
+                        ),
                       ),
                       style: ButtonStyle(
-                        backgroundColor: WidgetStatePropertyAll(OTLColor.grayF),
+                        backgroundColor: WidgetStatePropertyAll(
+                          context.colors.backgroundSectionDefault,
+                        ),
                         shape: WidgetStatePropertyAll(
                           RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(8.0),
@@ -118,7 +121,10 @@ class _CourseSearchPageState extends State<CourseSearchPage> {
                           _focusNode.requestFocus();
                         }
                       },
-                      child: Text("common.search".tr(), style: bodyBold),
+                      child: Text(
+                        "common.search".tr(),
+                        style: context.texts.normalBold,
+                      ),
                     ),
                   ),
                 ],

--- a/lib/pages/dictionary_page.dart
+++ b/lib/pages/dictionary_page.dart
@@ -1,8 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/pages/course_detail_page.dart';
 import 'package:otlplus/pages/course_search_page.dart';
 import 'package:otlplus/utils/navigator.dart';
@@ -47,7 +46,7 @@ class _DictionaryPageState extends State<DictionaryPage> {
                     height: 24.0,
                     width: 24.0,
                     colorFilter: ColorFilter.mode(
-                      OTLColor.pinksMain,
+                      context.colors.highlightDefault,
                       BlendMode.srcIn,
                     ),
                   ),
@@ -58,18 +57,18 @@ class _DictionaryPageState extends State<DictionaryPage> {
                 ],
               ),
             ),
-            color: OTLColor.grayF,
+            color: context.colors.backgroundSectionDefault,
           ),
         ),
       ),
       body: ColoredBox(
-        color: OTLColor.grayF,
+        color: context.colors.backgroundSectionDefault,
         child: Builder(
           builder: (context) {
             if (searchModel.isSearching) {
               return const Center(child: CircularProgressIndicator());
             } else if (searchModel.courses == null) {
-              return Center(child: _buildCopyRight());
+              return Center(child: _buildCopyRight(context));
             } else if (searchModel.courses!.isEmpty) {
               return Center(
                 child: Column(
@@ -77,7 +76,9 @@ class _DictionaryPageState extends State<DictionaryPage> {
                   children: [
                     Text(
                       "common.no_result".tr(),
-                      style: bodyRegular.copyWith(color: OTLColor.grayA),
+                      style: context.texts.normal.copyWith(
+                        color: context.colors.textDisable,
+                      ),
                     ),
                   ],
                 ),
@@ -109,10 +110,12 @@ class _DictionaryPageState extends State<DictionaryPage> {
   }
 }
 
-Widget _buildCopyRight() {
+Widget _buildCopyRight(BuildContext context) {
   return Text.rich(
     TextSpan(
-      style: labelRegular.copyWith(color: OTLColor.grayA),
+      style: context.texts.small.copyWith(
+        color: context.colors.textDisable,
+      ),
       children: [
         TextSpan(text: 'otlplus@sparcs.org'),
         TextSpan(text: '\n'),

--- a/lib/pages/dictionary_page.dart
+++ b/lib/pages/dictionary_page.dart
@@ -113,9 +113,7 @@ class _DictionaryPageState extends State<DictionaryPage> {
 Widget _buildCopyRight(BuildContext context) {
   return Text.rich(
     TextSpan(
-      style: context.texts.small.copyWith(
-        color: context.colors.textDisable,
-      ),
+      style: context.texts.small.copyWith(color: context.colors.textDisable),
       children: [
         TextSpan(text: 'otlplus@sparcs.org'),
         TextSpan(text: '\n'),

--- a/lib/pages/lecture_search_page.dart
+++ b/lib/pages/lecture_search_page.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/providers/lecture_search_model.dart';
 import 'package:otlplus/providers/timetable_model.dart';
 import 'package:otlplus/utils/navigator.dart';
@@ -53,7 +52,7 @@ class _LectureSearchPageState extends State<LectureSearchPage> {
           padding: EdgeInsets.only(right: 16.0),
           child: SearchTextfield(
             autoFocus: _searchTextController.text == '' && widget.openKeyboard,
-            backgroundColor: OTLColor.grayF,
+            backgroundColor: context.colors.backgroundSectionDefault,
             textController: _searchTextController,
             focusNode: _focusNode,
           ),
@@ -91,10 +90,14 @@ class _LectureSearchPageState extends State<LectureSearchPage> {
                       },
                       child: Text(
                         "common.reset_all".tr(),
-                        style: bodyBold.copyWith(color: OTLColor.pinksMain),
+                        style: context.texts.normalBold.copyWith(
+                          color: context.colors.highlightDefault,
+                        ),
                       ),
                       style: ButtonStyle(
-                        backgroundColor: WidgetStatePropertyAll(OTLColor.grayF),
+                        backgroundColor: WidgetStatePropertyAll(
+                          context.colors.backgroundSectionDefault,
+                        ),
                         shape: WidgetStatePropertyAll(
                           RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(8.0),
@@ -124,7 +127,10 @@ class _LectureSearchPageState extends State<LectureSearchPage> {
                         else
                           _focusNode.requestFocus();
                       },
-                      child: Text("common.search".tr(), style: bodyBold),
+                      child: Text(
+                        "common.search".tr(),
+                        style: context.texts.normalBold,
+                      ),
                     ),
                   ),
                 ],

--- a/lib/widgets/course_block.dart
+++ b/lib/widgets/course_block.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/extensions/course.dart';
 import 'package:otlplus/models/course.dart';
 import 'package:otlplus/widgets/responsive_button.dart';
@@ -19,7 +18,7 @@ class CourseBlock extends StatelessWidget {
     return ClipRRect(
       borderRadius: BorderRadius.circular(4.0),
       child: BackgroundButton(
-        color: OTLColor.grayE,
+        color: context.colors.lineDefault,
         onTap: onTap,
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 8.0),
@@ -31,23 +30,26 @@ class CourseBlock extends StatelessWidget {
                   children: <TextSpan>[
                     TextSpan(
                       text: isEn ? course.titleEn : course.title,
-                      style: bodyBold,
+                      style: context.texts.normalBold,
                     ),
                     const TextSpan(text: " "),
-                    TextSpan(text: course.oldCode, style: bodyRegular),
+                    TextSpan(
+                      text: course.oldCode,
+                      style: context.texts.normal,
+                    ),
                   ],
                 ),
               ),
-              _buildDivider(),
+              _buildDivider(context),
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Text("dictionary.type".tr(), style: labelBold),
+                  Text("dictionary.type".tr(), style: context.texts.smallBold),
                   const SizedBox(width: 8.0),
                   Expanded(
                     child: Text(
                       "${isEn ? course.department?.nameEn : course.department?.name}, ${isEn ? course.typeEn : course.type}",
-                      style: labelRegular,
+                      style: context.texts.small,
                     ),
                   ),
                 ],
@@ -56,12 +58,15 @@ class CourseBlock extends StatelessWidget {
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Text("dictionary.professors".tr(), style: labelBold),
+                  Text(
+                    "dictionary.professors".tr(),
+                    style: context.texts.smallBold,
+                  ),
                   const SizedBox(width: 8.0),
                   Expanded(
                     child: Text(
                       isEn ? course.professorsStrEn : course.professorsStr,
-                      style: labelRegular,
+                      style: context.texts.small,
                     ),
                   ),
                 ],
@@ -70,9 +75,14 @@ class CourseBlock extends StatelessWidget {
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Text("dictionary.description".tr(), style: labelBold),
+                  Text(
+                    "dictionary.description".tr(),
+                    style: context.texts.smallBold,
+                  ),
                   const SizedBox(width: 8.0),
-                  Expanded(child: Text(course.summary, style: labelRegular)),
+                  Expanded(
+                    child: Text(course.summary, style: context.texts.small),
+                  ),
                 ],
               ),
             ],
@@ -82,7 +92,7 @@ class CourseBlock extends StatelessWidget {
     );
   }
 
-  Widget _buildDivider() {
-    return Divider(color: OTLColor.gray0.withValues(alpha: .25));
+  Widget _buildDivider(BuildContext context) {
+    return Divider(color: context.colors.textDark.withValues(alpha: .25));
   }
 }

--- a/lib/widgets/course_block.dart
+++ b/lib/widgets/course_block.dart
@@ -33,10 +33,7 @@ class CourseBlock extends StatelessWidget {
                       style: context.texts.normalBold,
                     ),
                     const TextSpan(text: " "),
-                    TextSpan(
-                      text: course.oldCode,
-                      style: context.texts.normal,
-                    ),
+                    TextSpan(text: course.oldCode, style: context.texts.normal),
                   ],
                 ),
               ),

--- a/lib/widgets/lecture_group_block.dart
+++ b/lib/widgets/lecture_group_block.dart
@@ -50,10 +50,7 @@ class LectureGroupBlock extends StatelessWidget {
                       style: context.texts.normalBold,
                     ),
                     const SizedBox(width: 4),
-                    Text(
-                      lectures.first.oldCode,
-                      style: context.texts.normal,
-                    ),
+                    Text(lectures.first.oldCode, style: context.texts.normal),
                   ],
                 ),
                 Text.rich(

--- a/lib/widgets/lecture_group_block.dart
+++ b/lib/widgets/lecture_group_block.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/widgets/lecture_group_block_row.dart';
 
@@ -21,7 +20,7 @@ class LectureGroupBlock extends StatelessWidget {
         padding: const EdgeInsets.only(top: 8.0),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(4.0),
-          color: OTLColor.grayE,
+          color: context.colors.lineDefault,
         ),
         child: Text("There is no lecture."),
       );
@@ -29,7 +28,7 @@ class LectureGroupBlock extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.all(Radius.circular(8.0)),
-        color: OTLColor.grayE,
+        color: context.colors.lineDefault,
       ),
       padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       child: Column(
@@ -48,15 +47,20 @@ class LectureGroupBlock extends StatelessWidget {
                       isEn
                           ? lectures.first.commonTitleEn
                           : lectures.first.commonTitle,
-                      style: bodyBold,
+                      style: context.texts.normalBold,
                     ),
                     const SizedBox(width: 4),
-                    Text(lectures.first.oldCode, style: bodyRegular),
+                    Text(
+                      lectures.first.oldCode,
+                      style: context.texts.normal,
+                    ),
                   ],
                 ),
                 Text.rich(
                   TextSpan(
-                    style: labelRegular.copyWith(color: OTLColor.grayA),
+                    style: context.texts.small.copyWith(
+                      color: context.colors.textDisable,
+                    ),
                     children: <TextSpan>[
                       TextSpan(text: lectures.first.departmentCode),
                       const TextSpan(text: " / "),
@@ -75,7 +79,7 @@ class LectureGroupBlock extends StatelessWidget {
             padding: EdgeInsets.symmetric(vertical: 4.0),
             child: SizedBox(
               height: 1,
-              child: ColoredBox(color: OTLColor.grayA),
+              child: ColoredBox(color: context.colors.textDisable),
             ),
           ),
           ...lectures.map(

--- a/lib/widgets/lecture_group_block_row.dart
+++ b/lib/widgets/lecture_group_block_row.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/extensions/lecture.dart';
 import 'package:otlplus/models/lecture.dart';
 import 'package:otlplus/widgets/otl_dialog.dart';
@@ -53,7 +52,9 @@ class _LectureGroupBlockRowState extends State<LectureGroupBlockRow> {
           },
           onLongPress: widget.onLongPress,
           child: Container(
-            decoration: BoxDecoration(color: selected ? OTLColor.grayD : null),
+            decoration: BoxDecoration(
+              color: selected ? context.colors.lineDark : null,
+            ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.center,
@@ -68,7 +69,7 @@ class _LectureGroupBlockRowState extends State<LectureGroupBlockRow> {
                             children: <InlineSpan>[
                               TextSpan(
                                 text: widget.lecture.classTitle,
-                                style: bodyBold,
+                                style: context.texts.normalBold,
                               ),
                               WidgetSpan(child: const SizedBox(width: 8)),
                               WidgetSpan(
@@ -76,7 +77,7 @@ class _LectureGroupBlockRowState extends State<LectureGroupBlockRow> {
                                   isEn
                                       ? widget.lecture.professorsStrShortEn
                                       : widget.lecture.professorsStrShort,
-                                  style: bodyRegular,
+                                  style: context.texts.normal,
                                 ),
                               ),
                             ],
@@ -100,7 +101,7 @@ class _LectureGroupBlockRowState extends State<LectureGroupBlockRow> {
                             icon: 'assets/icons/info.svg',
                             iconSize: 20.0,
                             onTap: widget.onLongPress,
-                            color: OTLColor.gray0,
+                            color: context.colors.textDark,
                           ),
                           SizedBox(width: 6.0),
                           IconTextButton(
@@ -116,8 +117,8 @@ class _LectureGroupBlockRowState extends State<LectureGroupBlockRow> {
                                 : 'assets/icons/add.svg',
                             iconSize: 24,
                             color: alreadyAdded
-                                ? OTLColor.pinksMain
-                                : OTLColor.gray0,
+                                ? context.colors.highlightDefault
+                                : context.colors.textDark,
                           ),
                         ],
                       ),

--- a/lib/widgets/search_filter_panel.dart
+++ b/lib/widgets/search_filter_panel.dart
@@ -1,8 +1,8 @@
 import 'dart:math' as math;
 import 'package:easy_localization/easy_localization.dart' as _;
 import 'package:flutter/material.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/constants/color.dart'; // legacy: OTLColor.pinksSub only
+import 'package:otlplus/theme/context_ext.dart';
 import 'package:otlplus/models/filter.dart';
 import 'package:otlplus/widgets/responsive_button.dart';
 import 'package:otlplus/utils/get_text_height.dart';
@@ -25,7 +25,7 @@ class _SearchFilterPanelState extends State<SearchFilterPanel> {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: OTLColor.grayF,
+        color: context.colors.backgroundSectionDefault,
         borderRadius: BorderRadius.circular(8.0),
       ),
       child: GestureDetector(
@@ -101,7 +101,7 @@ class _SelectorState extends State<Selector> {
                 Row(
                   crossAxisAlignment: CrossAxisAlignment.end,
                   children: [
-                    Text(widget.title, style: titleBold),
+                    Text(widget.title, style: context.texts.bigBold),
                     SizedBox(width: 8),
                     Visibility(
                       visible: widget.isMultiSelect,
@@ -124,7 +124,7 @@ class _SelectorState extends State<Selector> {
                                   ),
                                   TextSpan(text: "common.num_selected".tr()),
                                 ],
-                          style: bodyRegular,
+                          style: context.texts.normal,
                         ),
                       ),
                     ),
@@ -145,8 +145,8 @@ class _SelectorState extends State<Selector> {
                       });
                     },
                     text: "common.reset".tr(),
-                    textStyle: bodyRegular.copyWith(
-                      color: OTLColor.pinksMain,
+                    textStyle: context.texts.normal.copyWith(
+                      color: context.colors.highlightDefault,
                       decoration: TextDecoration.underline,
                     ),
                   ),
@@ -257,7 +257,9 @@ class _RadioSelectButtonState extends State<RadioSelectButton> {
       borderRadius: BorderRadius.circular(16.0),
       child: BackgroundButton(
         onTap: () => widget.setOption(!widget.option.selected),
-        color: widget.option.selected ? OTLColor.pinksSub : OTLColor.grayE,
+        color: widget.option.selected
+            ? OTLColor.pinksSub // legacy: no direct web token
+            : context.colors.lineDefault,
         child: SizedBox(
           height: 32.0,
           child: Padding(
@@ -267,15 +269,23 @@ class _RadioSelectButtonState extends State<RadioSelectButton> {
               children: [
                 Text(
                   widget.option.label.tr(),
-                  style: labelRegular.copyWith(
+                  style: context.texts.small.copyWith(
                     color: widget.option.selected
-                        ? OTLColor.gray0
-                        : OTLColor.grayA,
+                        ? context.colors.textDark
+                        : context.colors.textDisable,
                   ),
                 ),
                 widget.option.selected
-                    ? Icon(Icons.check, size: 16.0, color: OTLColor.gray0)
-                    : Icon(Icons.add, size: 16.0, color: OTLColor.grayA),
+                    ? Icon(
+                        Icons.check,
+                        size: 16.0,
+                        color: context.colors.textDark,
+                      )
+                    : Icon(
+                        Icons.add,
+                        size: 16.0,
+                        color: context.colors.textDisable,
+                      ),
               ],
             ),
           ),
@@ -303,7 +313,6 @@ class SilderSelection extends StatefulWidget {
 class _SilderSelectionState extends State<SilderSelection> {
   double _value = 0;
 
-  TextStyle labelTextStyle = TextStyle(fontSize: 12);
   @override
   void initState() {
     super.initState();
@@ -316,6 +325,7 @@ class _SilderSelectionState extends State<SilderSelection> {
 
   @override
   Widget build(BuildContext context) {
+    final labelTextStyle = TextStyle(fontSize: 12);
     final divisions = widget.selectList.length - 1;
     return Padding(
       padding: EdgeInsets.only(left: 2, right: 10),
@@ -349,8 +359,11 @@ class _SilderSelectionState extends State<SilderSelection> {
                     thumbShape: CustomSliderThumbShape(
                       outerThumbRadius: 10,
                       innerThumbRadius: 7,
-                      outerThumbColor: OTLColor.pinksSub,
-                      innerThumbColor: OTLColor.grayF,
+                      outerThumbColor:
+                          OTLColor.pinksSub, // legacy: no direct web token
+                      innerThumbColor:
+                          context.colors.backgroundSectionDefault,
+                      shadowColor: context.colors.textDark,
                     ),
                     trackHeight: 5.0,
                     trackShape: RoundRectangularSliderTrackShape(),
@@ -362,8 +375,9 @@ class _SilderSelectionState extends State<SilderSelection> {
                     min: 0.0,
                     max: divisions.toDouble(),
                     divisions: divisions,
-                    activeColor: OTLColor.pinksSub,
-                    inactiveColor: OTLColor.grayE,
+                    activeColor:
+                        OTLColor.pinksSub, // legacy: no direct web token
+                    inactiveColor: context.colors.lineDefault,
                     onChanged: (double value) {
                       setState(() {
                         _value = value;
@@ -519,8 +533,9 @@ class CustomSliderThumbShape extends SliderComponentShape {
   const CustomSliderThumbShape({
     this.outerThumbRadius = 10.0,
     this.innerThumbRadius = 10.0,
-    this.outerThumbColor = OTLColor.grayF,
-    this.innerThumbColor = OTLColor.grayF,
+    required this.outerThumbColor,
+    required this.innerThumbColor,
+    this.shadowColor = Colors.black,
     this.elevation = 0.0,
     this.pressedElevation = 0.0,
   });
@@ -528,6 +543,7 @@ class CustomSliderThumbShape extends SliderComponentShape {
   final double innerThumbRadius;
   final Color outerThumbColor;
   final Color innerThumbColor;
+  final Color shadowColor;
   final double elevation;
   final double pressedElevation;
 
@@ -575,7 +591,7 @@ class CustomSliderThumbShape extends SliderComponentShape {
     bool paintShadows = true;
 
     if (paintShadows) {
-      canvas.drawShadow(path, OTLColor.gray0, evaluatedElevation, true);
+      canvas.drawShadow(path, shadowColor, evaluatedElevation, true);
     }
 
     canvas

--- a/lib/widgets/search_filter_panel.dart
+++ b/lib/widgets/search_filter_panel.dart
@@ -258,7 +258,8 @@ class _RadioSelectButtonState extends State<RadioSelectButton> {
       child: BackgroundButton(
         onTap: () => widget.setOption(!widget.option.selected),
         color: widget.option.selected
-            ? OTLColor.pinksSub // legacy: no direct web token
+            ? OTLColor
+                  .pinksSub // legacy: no direct web token
             : context.colors.lineDefault,
         child: SizedBox(
           height: 32.0,
@@ -361,8 +362,7 @@ class _SilderSelectionState extends State<SilderSelection> {
                       innerThumbRadius: 7,
                       outerThumbColor:
                           OTLColor.pinksSub, // legacy: no direct web token
-                      innerThumbColor:
-                          context.colors.backgroundSectionDefault,
+                      innerThumbColor: context.colors.backgroundSectionDefault,
                       shadowColor: context.colors.textDark,
                     ),
                     trackHeight: 5.0,

--- a/lib/widgets/search_textfield.dart
+++ b/lib/widgets/search_textfield.dart
@@ -1,8 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:otlplus/constants/color.dart';
-import 'package:otlplus/constants/text_styles.dart';
+import 'package:otlplus/theme/context_ext.dart';
 
 class SearchTextfield extends StatefulWidget {
   const SearchTextfield({
@@ -27,7 +26,7 @@ class _SearchTextfieldState extends State<SearchTextfield> {
     return ClipRRect(
       borderRadius: BorderRadius.circular(8.0),
       child: ColoredBox(
-        color: OTLColor.grayF,
+        color: context.colors.backgroundSectionDefault,
         child: Padding(
           padding: EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
           child: Row(
@@ -37,7 +36,7 @@ class _SearchTextfieldState extends State<SearchTextfield> {
                 height: 24.0,
                 width: 24.0,
                 colorFilter: ColorFilter.mode(
-                  OTLColor.pinksMain,
+                  context.colors.highlightDefault,
                   BlendMode.srcIn,
                 ),
               ),
@@ -50,10 +49,12 @@ class _SearchTextfieldState extends State<SearchTextfield> {
                   onSubmitted: (value) {
                     widget.focusNode?.unfocus();
                   },
-                  style: bodyRegular,
+                  style: context.texts.normal,
                   decoration: InputDecoration(
                     hintText: "common.search_hint".tr(),
-                    hintStyle: bodyRegular.copyWith(color: OTLColor.grayA),
+                    hintStyle: context.texts.normal.copyWith(
+                      color: context.colors.textPlaceholder,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Coordinated redesign stream — Stage 4 of 6

This PR migrates **8 files** in the **search + dictionary** surface from legacy `OTLColor.*` + `lib/constants/text_styles.dart` constants to the new `context.colors` / `context.texts` design-system tokens introduced in **Foundation PR #237**.

| Stage | PR | Domain | Status |
|-------|----|--------|--------|
| 1 | #237 | foundation theme | ready to merge |
| 2 | #238 | home + timetable | draft |
| 3 | #236 | account + settings | draft |
| 4 | #241 | search + dictionary | draft |
| 5 | #240 | course + lecture detail | draft |
| 6 | #239 | reviews | draft |

### Dependency
This PR will **not compile standalone** — it imports `package:otlplus/theme/context_ext.dart` which is introduced in #237. The import error resolves once #237 merges and this branch is rebased onto `main` (use `scripts/rebase-onto-foundation.sh --cleanup` from #237).

---

## Summary

PR 4 of N in the coordinated UI redesign stream. Migrates the **search + dictionary surface** (8 files) from legacy `OTLColor`/`text_styles` constants to the new design-system tokens introduced in foundation PR #237.

### Token Mapping Applied

| Legacy | New Token |
|--------|-----------|
| `OTLColor.gray0` | `context.colors.textDark` |
| `OTLColor.grayA` | `context.colors.textDisable` / `textPlaceholder` |
| `OTLColor.grayD` | `context.colors.lineDark` |
| `OTLColor.grayE` | `context.colors.lineDefault` |
| `OTLColor.grayF` | `context.colors.backgroundSectionDefault` |
| `OTLColor.pinksMain` | `context.colors.highlightDefault` |
| `OTLColor.pinksSub` | kept as `// legacy: no direct web token` |
| `bodyRegular`/`bodyBold` | `context.texts.normal`/`normalBold` |
| `labelRegular`/`labelBold` | `context.texts.small`/`smallBold` |
| `titleBold` | `context.texts.bigBold` |

### Files Changed

- `lib/pages/course_search_page.dart` — token migration
- `lib/pages/lecture_search_page.dart` — token migration
- `lib/pages/dictionary_page.dart` — token migration + `_buildCopyRight` now takes `BuildContext`
- `lib/widgets/search_textfield.dart` — token migration
- `lib/widgets/search_filter_panel.dart` — token migration + `CustomSliderThumbShape` now receives colors via constructor (no more `OTLColor` defaults)
- `lib/widgets/course_block.dart` — token migration + `_buildDivider` now takes `BuildContext`
- `lib/widgets/lecture_group_block.dart` — token migration
- `lib/widgets/lecture_group_block_row.dart` — token migration

### Dependency

> **⚠️ DRAFT — depends on foundation PR #237 (`ui-redesign/foundation-theme`).** This branch will NOT compile standalone. Merge foundation first, then rebase this branch.

Foundation branch: [`ui-redesign/foundation-theme`](https://github.com/sparcs-kaist/otlplus-app/tree/ui-redesign/foundation-theme)