### PR TITLE
feat: add Android in-app update (cherry-picked from #235, no widget breaking changes)

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -240,6 +240,8 @@
   },
   "popup": {
     "dont_show_again": "Don't Show Again",
-    "join_the_event": "Join the Event"
+    "join_the_event": "Join the Event",
+    "inapp_flexible_download_complete": "Update download is complete.",
+    "inapp_flexible_restart": "Restart"
   }
 }

--- a/assets/translations/ko.json
+++ b/assets/translations/ko.json
@@ -241,6 +241,8 @@
   },
   "popup": {
     "dont_show_again": "다시 보지 않기",
-    "join_the_event": "이벤트 참여하러 가기"
+    "join_the_event": "이벤트 참여하러 가기",
+    "inapp_flexible_download_complete": "업데이트 다운로드가 완료되었습니다.",
+    "inapp_flexible_restart": "재시작"
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:app_links/app_links.dart';
 import 'package:dio/dio.dart';
@@ -6,6 +7,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
+import 'package:in_app_update/in_app_update.dart';
 import 'package:otlplus/constants/url.dart';
 import 'package:otlplus/dio_provider.dart';
 import 'package:otlplus/pages/course_detail_page.dart';
@@ -146,12 +148,55 @@ class _OTLAppState extends State<OTLApp> {
   final _storageService = StorageService();
   final _dio = DioProvider().dio;
   bool _isLoading = true;
+  final GlobalKey<ScaffoldMessengerState> _scaffoldMessengerKey =
+      GlobalKey<ScaffoldMessengerState>();
 
   @override
   void initState() {
     super.initState();
     _initializeApp();
     _initDeepLinks();
+    _checkForUpdate();
+  }
+
+  Future<void> _checkForUpdate() async {
+    if (Platform.isAndroid) {
+      try {
+        final info = await InAppUpdate.checkForUpdate();
+        if (info.updateAvailability == UpdateAvailability.updateAvailable) {
+          if (info.immediateUpdateAllowed && info.updatePriority >= 4) {
+            final result = await InAppUpdate.performImmediateUpdate();
+            if (result == AppUpdateResult.userDeniedUpdate) {
+              exit(0);
+            }
+          } else if (info.flexibleUpdateAllowed) {
+            await InAppUpdate.startFlexibleUpdate().then((_) {
+              _showUpdateSnackbar();
+            });
+          }
+        } else if (info.updateAvailability ==
+            UpdateAvailability.developerTriggeredUpdateInProgress) {
+          await InAppUpdate.performImmediateUpdate();
+        }
+      } catch (e) {
+        debugPrint("In-app update error: $e");
+      }
+    }
+  }
+
+  void _showUpdateSnackbar() {
+    _scaffoldMessengerKey.currentState?.showSnackBar(
+      SnackBar(
+        content: Text("popup.inapp_flexible_download_complete".tr()),
+        duration: const Duration(days: 1),
+        action: SnackBarAction(
+          label: "popup.inapp_flexible_restart".tr(),
+          onPressed: () async {
+            await InAppUpdate.completeFlexibleUpdate();
+          },
+        ),
+      ),
+    );
   }
 
   @override
@@ -256,12 +301,14 @@ class _OTLAppState extends State<OTLApp> {
 
     if (_isLoading) {
       return MaterialApp(
+        scaffoldMessengerKey: _scaffoldMessengerKey,
         home: Scaffold(body: Center(child: CircularProgressIndicator())),
       );
     }
 
     final authModel = context.watch<AuthModel>();
     return MaterialApp(
+      scaffoldMessengerKey: _scaffoldMessengerKey,
       builder: (context, child) {
         try {
           final sendCrashlytics = context

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
     git:
       url: https://github.com/happycastle114/channel_talk_flutter
       ref: main
+  in_app_update: ^4.2.5
 dev_dependencies:
   test: "^1.25.7"
   http: "^1.2.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 ---
 name: otlplus
 description: Online Timeplanner with Lectures Plus App @ KAIST
-version: 2.5.17+260108
+version: 2.5.18+260109
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: ">=3.32.0"


### PR DESCRIPTION
## Summary

Cherry-picks the **in-app update** commit from #235 onto `main` directly, **excluding** the breaking widget API v2 changes from #234 that #235 was originally based on.

This is the cleaner version of #235, ready to merge and deploy.

## What's included

- `1dc2508` feat: add inapp update to android — adds Android in-app update flow (Play Core / `in_app_update`) with flexible/immediate update handling and KO/EN snackbar copy.
- `chore` version bump `2.5.17+260108` → `2.5.18+260109` to trigger a fresh deploy.

## What's NOT included (intentionally excluded)

The 6 commits from base PR #234 (`feat@widgets-fix`) that contain breaking API v2 changes:
- `332c0ad` android widget bug fix, api upgrade to v2
- `40be697` ios widget api upgrade to v2
- `8afe0a8` fix ios widget bug and add subtitles for widget
- `35e0a59` remove log
- `2ccf484` add course color to next lecture widget
- `318002a` fix android widget update bug

Those will continue to live on #234 / #235 and can be reviewed/merged separately when ready.

## Files changed

- `pubspec.yaml` — adds `in_app_update: ^4.2.5`, bumps version
- `lib/main.dart` — `_checkForUpdate()` flow on Android startup, scaffold messenger key for restart snackbar
- `assets/translations/{en,ko}.json` — `inapp_flexible_download_complete`, `inapp_flexible_restart` strings

## Deployment

After merge, tagging `v2.5.18` will trigger `.github/workflows/deploy.yml` → Google Play Alpha + TestFlight.

Closes #235 (in-app update portion only).
