### PR TITLE
fix(ci): explicit manual signing + ASC API key for iOS deploy (8 consecutive failures)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -435,33 +435,52 @@ jobs:
           
           echo "🎉 All iOS certificate and profile validations passed!"
 
-      - name: Extract provisioning profile names
+      - name: Extract provisioning profile metadata
         run: |
           set -euo pipefail
           PP_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
 
-          extract_name() {
+          extract_field() {
             local file="$1"
+            local field="$2"
             if [ ! -f "$file" ]; then
               echo ""
               return
             fi
             security cms -D -i "$file" 2>/dev/null \
-              | plutil -extract Name raw - 2>/dev/null \
+              | plutil -extract "$field" raw - 2>/dev/null \
               || true
           }
 
-          MAIN_NAME=$(extract_name "$PP_DIR/profile.mobileprovision")
-          WIDGET_NAME=$(extract_name "$PP_DIR/profile_widget.mobileprovision")
-          INTENTS_NAME=$(extract_name "$PP_DIR/profile_intents.mobileprovision")
+          install_by_uuid() {
+            local file="$1"
+            local uuid
+            uuid=$(extract_field "$file" UUID)
+            if [ -n "$uuid" ]; then
+              cp "$file" "$PP_DIR/$uuid.mobileprovision"
+            fi
+            echo "$uuid"
+          }
 
-          echo "📋 Extracted profile names:"
-          echo "  • Main:    ${MAIN_NAME:-<missing>}"
-          echo "  • Widget:  ${WIDGET_NAME:-<missing>}"
-          echo "  • Intents: ${INTENTS_NAME:-<missing>}"
+          MAIN_PROFILE="$PP_DIR/profile.mobileprovision"
+          WIDGET_PROFILE="$PP_DIR/profile_widget.mobileprovision"
+          INTENTS_PROFILE="$PP_DIR/profile_intents.mobileprovision"
 
-          if [ -z "$MAIN_NAME" ] || [ -z "$WIDGET_NAME" ] || [ -z "$INTENTS_NAME" ]; then
-            echo "⚠️  At least one profile name is empty — Fastfile will fall back to legacy build_app config."
+          MAIN_NAME=$(extract_field "$MAIN_PROFILE" Name)
+          WIDGET_NAME=$(extract_field "$WIDGET_PROFILE" Name)
+          INTENTS_NAME=$(extract_field "$INTENTS_PROFILE" Name)
+          MAIN_UUID=$(install_by_uuid "$MAIN_PROFILE")
+          WIDGET_UUID=$(install_by_uuid "$WIDGET_PROFILE")
+          INTENTS_UUID=$(install_by_uuid "$INTENTS_PROFILE")
+
+          echo "📋 Extracted profile metadata:"
+          echo "  • Main:    ${MAIN_NAME:-<missing>} (${MAIN_UUID:-missing UUID})"
+          echo "  • Widget:  ${WIDGET_NAME:-<missing>} (${WIDGET_UUID:-missing UUID})"
+          echo "  • Intents: ${INTENTS_NAME:-<missing>} (${INTENTS_UUID:-missing UUID})"
+
+          if [ -z "$MAIN_NAME" ] || [ -z "$WIDGET_NAME" ] || [ -z "$INTENTS_NAME" ] ||
+             [ -z "$MAIN_UUID" ] || [ -z "$WIDGET_UUID" ] || [ -z "$INTENTS_UUID" ]; then
+            echo "⚠️  At least one profile name or UUID is empty — Fastfile will fall back to legacy build_app config."
             echo "    For App Store export this will likely fail. Verify all 3 IOS_PROVISIONING_PROFILE* secrets."
           fi
 
@@ -469,6 +488,9 @@ jobs:
             echo "IOS_PROFILE_NAME=$MAIN_NAME"
             echo "IOS_WIDGET_PROFILE_NAME=$WIDGET_NAME"
             echo "IOS_INTENTS_PROFILE_NAME=$INTENTS_NAME"
+            echo "IOS_PROFILE_UUID=$MAIN_UUID"
+            echo "IOS_WIDGET_PROFILE_UUID=$WIDGET_UUID"
+            echo "IOS_INTENTS_PROFILE_UUID=$INTENTS_UUID"
           } >> "$GITHUB_ENV"
 
       - name: Install Flutter dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,6 +232,9 @@ jobs:
       IOS_PROVISIONING_PROFILE: ${{ secrets.IOS_PROVISIONING_PROFILE }}
       IOS_PROVISIONING_PROFILE_WIDGET: ${{ secrets.IOS_PROVISIONING_PROFILE_WIDGET }}
       IOS_PROVISIONING_PROFILE_INTENTS: ${{ secrets.IOS_PROVISIONING_PROFILE_INTENTS }}
+      APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout code
@@ -432,12 +435,61 @@ jobs:
           
           echo "🎉 All iOS certificate and profile validations passed!"
 
+      - name: Extract provisioning profile names
+        run: |
+          set -euo pipefail
+          PP_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+
+          extract_name() {
+            local file="$1"
+            if [ ! -f "$file" ]; then
+              echo ""
+              return
+            fi
+            security cms -D -i "$file" 2>/dev/null \
+              | plutil -extract Name raw - 2>/dev/null \
+              || true
+          }
+
+          MAIN_NAME=$(extract_name "$PP_DIR/profile.mobileprovision")
+          WIDGET_NAME=$(extract_name "$PP_DIR/profile_widget.mobileprovision")
+          INTENTS_NAME=$(extract_name "$PP_DIR/profile_intents.mobileprovision")
+
+          echo "📋 Extracted profile names:"
+          echo "  • Main:    ${MAIN_NAME:-<missing>}"
+          echo "  • Widget:  ${WIDGET_NAME:-<missing>}"
+          echo "  • Intents: ${INTENTS_NAME:-<missing>}"
+
+          if [ -z "$MAIN_NAME" ] || [ -z "$WIDGET_NAME" ] || [ -z "$INTENTS_NAME" ]; then
+            echo "⚠️  At least one profile name is empty — Fastfile will fall back to legacy build_app config."
+            echo "    For App Store export this will likely fail. Verify all 3 IOS_PROVISIONING_PROFILE* secrets."
+          fi
+
+          {
+            echo "IOS_PROFILE_NAME=$MAIN_NAME"
+            echo "IOS_WIDGET_PROFILE_NAME=$WIDGET_NAME"
+            echo "IOS_INTENTS_PROFILE_NAME=$INTENTS_NAME"
+          } >> "$GITHUB_ENV"
+
       - name: Install Flutter dependencies
         run: flutter pub get
 
       - name: Install CocoaPods dependencies
         working-directory: ios
         run: pod install
+
+      - name: Debug App Store Connect API key availability
+        run: |
+          if [ -n "$APP_STORE_CONNECT_KEY_ID" ] && [ -n "$APP_STORE_CONNECT_ISSUER_ID" ] && [ -n "$APP_STORE_CONNECT_API_KEY" ]; then
+            echo "✅ App Store Connect API key is configured — TestFlight upload will use API key auth"
+          else
+            echo "⚠️  App Store Connect API key NOT fully configured — falling back to APPLE_ID + APPLE_PASSWORD auth"
+            echo "   This often fails when 2FA is enabled or APPLE_PASSWORD is not an app-specific password."
+            echo "   To fix: add these GitHub secrets:"
+            echo "     - APP_STORE_CONNECT_KEY_ID"
+            echo "     - APP_STORE_CONNECT_ISSUER_ID"
+            echo "     - APP_STORE_CONNECT_API_KEY  (.p8 file content, raw or base64)"
+          fi
 
       - name: Deploy to TestFlight
         working-directory: ios

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -15,6 +15,30 @@
 
 default_platform(:ios)
 
+def apply_release_profile(target:, profile_path:, team_id:)
+  unless File.exist?(profile_path)
+    UI.user_error!("Missing provisioning profile for #{target}: #{profile_path}")
+  end
+
+  update_code_signing_settings(
+    use_automatic_signing: false,
+    path: "Runner.xcodeproj",
+    team_id: team_id,
+    targets: [target],
+    build_configurations: ["Release"],
+    code_sign_identity: "Apple Distribution",
+    sdk: "iphoneos*",
+  )
+
+  update_project_provisioning(
+    xcodeproj: "Runner.xcodeproj",
+    profile: profile_path,
+    target_filter: "^#{Regexp.escape(target)}$",
+    build_configuration: "Release",
+    code_signing_identity: "Apple Distribution",
+  )
+end
+
 platform :ios do
   desc "Push a new beta build to TestFlight"
   lane :alpha do
@@ -31,13 +55,27 @@ platform :ios do
     main_profile    = ENV["IOS_PROFILE_NAME"]
     widget_profile  = ENV["IOS_WIDGET_PROFILE_NAME"]
     intents_profile = ENV["IOS_INTENTS_PROFILE_NAME"]
+    main_profile_uuid    = ENV["IOS_PROFILE_UUID"]
+    widget_profile_uuid  = ENV["IOS_WIDGET_PROFILE_UUID"]
+    intents_profile_uuid = ENV["IOS_INTENTS_PROFILE_UUID"]
+    profile_dir = File.expand_path("~/Library/MobileDevice/Provisioning Profiles")
+    main_profile_path = File.join(profile_dir, "profile.mobileprovision")
+    widget_profile_path = File.join(profile_dir, "profile_widget.mobileprovision")
+    intents_profile_path = File.join(profile_dir, "profile_intents.mobileprovision")
 
     use_manual_signing = !main_profile.to_s.empty? &&
                          !widget_profile.to_s.empty? &&
-                         !intents_profile.to_s.empty?
+                         !intents_profile.to_s.empty? &&
+                         !main_profile_uuid.to_s.empty? &&
+                         !widget_profile_uuid.to_s.empty? &&
+                         !intents_profile_uuid.to_s.empty?
 
     if use_manual_signing
       UI.message("📝 Using manual code signing with explicit provisioning profiles")
+      apply_release_profile(target: "Runner", profile_path: main_profile_path, team_id: team_id)
+      apply_release_profile(target: "OTLWidgetsExtension", profile_path: widget_profile_path, team_id: team_id)
+      apply_release_profile(target: "OTLPlusIntents", profile_path: intents_profile_path, team_id: team_id)
+
       build_app(
         workspace: "Runner.xcworkspace",
         scheme: "Runner",
@@ -54,9 +92,9 @@ platform :ios do
           signingStyle: "manual",
           teamID: team_id,
           provisioningProfiles: {
-            "org.sparcs.otlplus"         => main_profile,
-            "org.sparcs.otlplus.widget"  => widget_profile,
-            "org.sparcs.otlplus.intents" => intents_profile,
+            "org.sparcs.otlplus"         => main_profile_uuid,
+            "org.sparcs.otlplus.widget"  => widget_profile_uuid,
+            "org.sparcs.otlplus.intents" => intents_profile_uuid,
           },
         },
       )

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -25,19 +25,76 @@ platform :ios do
     sh "flutter pub get"
     sh "bundle exec pod install"
 
-    update_project_team(
-      teamid: CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
-    )
+    team_id = CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
+    update_project_team(teamid: team_id)
 
-    build_app(
-      workspace: "Runner.xcworkspace",
-      scheme: "Runner",
-      clean: true,
-      export_method: "app-store",
-      destination: "generic/platform=iOS",
-    )
-    upload_to_testflight(
-      skip_waiting_for_build_processing: true,
-    )
+    main_profile    = ENV["IOS_PROFILE_NAME"]
+    widget_profile  = ENV["IOS_WIDGET_PROFILE_NAME"]
+    intents_profile = ENV["IOS_INTENTS_PROFILE_NAME"]
+
+    use_manual_signing = !main_profile.to_s.empty? &&
+                         !widget_profile.to_s.empty? &&
+                         !intents_profile.to_s.empty?
+
+    if use_manual_signing
+      UI.message("📝 Using manual code signing with explicit provisioning profiles")
+      build_app(
+        workspace: "Runner.xcworkspace",
+        scheme: "Runner",
+        clean: true,
+        export_method: "app-store",
+        destination: "generic/platform=iOS",
+        xcargs: [
+          "DEVELOPMENT_TEAM=#{team_id}",
+          "CODE_SIGN_STYLE=Manual",
+          "CODE_SIGN_IDENTITY='Apple Distribution'",
+        ].join(" "),
+        export_options: {
+          method: "app-store",
+          signingStyle: "manual",
+          teamID: team_id,
+          provisioningProfiles: {
+            "org.sparcs.otlplus"         => main_profile,
+            "org.sparcs.otlplus.widget"  => widget_profile,
+            "org.sparcs.otlplus.intents" => intents_profile,
+          },
+        },
+      )
+    else
+      UI.message("⚠️ IOS_*_PROFILE_NAME env vars not set, falling back to legacy build_app config")
+      build_app(
+        workspace: "Runner.xcworkspace",
+        scheme: "Runner",
+        clean: true,
+        export_method: "app-store",
+        destination: "generic/platform=iOS",
+      )
+    end
+
+    asc_key_id     = ENV["APP_STORE_CONNECT_KEY_ID"]
+    asc_issuer_id  = ENV["APP_STORE_CONNECT_ISSUER_ID"]
+    asc_key_content = ENV["APP_STORE_CONNECT_API_KEY"]
+
+    if !asc_key_id.to_s.empty? && !asc_issuer_id.to_s.empty? && !asc_key_content.to_s.empty?
+      UI.message("🔑 Using App Store Connect API key for upload")
+      # Auto-detect: raw .p8 files contain "BEGIN PRIVATE KEY"; otherwise treat as base64
+      is_base64 = !asc_key_content.include?("BEGIN PRIVATE KEY")
+      api_key = app_store_connect_api_key(
+        key_id: asc_key_id,
+        issuer_id: asc_issuer_id,
+        key_content: asc_key_content,
+        is_key_content_base64: is_base64,
+        in_house: false,
+      )
+      upload_to_testflight(
+        api_key: api_key,
+        skip_waiting_for_build_processing: true,
+      )
+    else
+      UI.message("🔑 Using Apple ID + app-specific password for upload (legacy)")
+      upload_to_testflight(
+        skip_waiting_for_build_processing: true,
+      )
+    end
   end
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 ---
 name: otlplus
 description: Online Timeplanner with Lectures Plus App @ KAIST
-version: 2.5.18+260109
+version: 2.5.19+260604
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: ">=3.32.0"


### PR DESCRIPTION
## Why

iOS TestFlight 배포가 **8연속 실패** (v2.5.10 → v2.5.17). 모두 정확히 같은 step `Deploy to TestFlight` (= `bundle exec fastlane alpha`)에서 죽었음. v2.5.18도 미수정 시 동일하게 실패할 예정.

## Root cause (Oracle 분석)

| 문제 | 현재 상태 | 필요한 상태 |
|---|---|---|
| Code signing identity | `Apple Development` (Automatic) | `Apple Distribution` (Manual) |
| Provisioning profile mapping | 없음 (build_app에 export_options 미지정) | 3개 bundle ID 명시 매핑 |
| TestFlight 업로드 인증 | `APPLE_PASSWORD` (regular pw, 2FA 막힘) | App Store Connect API key |
| `-allowProvisioningUpdates` 시도 | `4d7f261`에서 추가, `ce48985`에서 롤백 (Apple ID 로그인 필요) | 사용 안 함 |

요약: CI엔 Apple Developer Portal 로그인 세션이 없어서 Automatic signing이 작동 못 함. App Store export는 Distribution 인증서 + 명시적 프로파일 매핑이 필수.

## What this PR changes (코드만 — 시크릿은 별도 작업 필요)

### `ios/fastlane/Fastfile`
- `IOS_*_PROFILE_NAME` env var가 모두 set이면 **manual signing + explicit `export_options`** 사용
  - `xcargs`로 `CODE_SIGN_STYLE=Manual`, `CODE_SIGN_IDENTITY='Apple Distribution'`, `DEVELOPMENT_TEAM` 강제
  - `export_options.provisioningProfiles`에 3개 bundle ID 매핑:
    - `org.sparcs.otlplus`
    - `org.sparcs.otlplus.widget`
    - `org.sparcs.otlplus.intents`
- 그렇지 않으면 기존 build_app config로 fallback (graceful degradation)
- `APP_STORE_CONNECT_*` 3개 env var가 모두 set이면 **App Store Connect API key**로 업로드, 아니면 기존 Apple ID 비번 방식 유지
  - `.p8` 원본인지 base64인지 자동 감지 (`BEGIN PRIVATE KEY` 포함 여부로 판별)

### `.github/workflows/deploy.yml`
- 새 step **"Extract provisioning profile names"** — 설치된 `.mobileprovision` 파일에서 `security cms` + `plutil`로 Name 추출 → `GITHUB_ENV` 주입
  - 어떤 profile name이 비어있으면 경고 로그 + Fastfile이 fallback 모드로 진입
- 새 step **"Debug App Store Connect API key availability"** — 어느 인증 경로를 쓸지 미리 알려줌
- `APP_STORE_CONNECT_KEY_ID` / `_ISSUER_ID` / `_API_KEY` 시크릿을 deploy-ios job env에 추가

### Backwards compatibility
이 PR만 머지하고 시크릿을 안 추가하면 → 동작은 **현재(실패)와 동일**. 시크릿을 추가해야 실제로 통과함.

## ⚠️ 머지 후 필수 작업 (사용자만 할 수 있음)

### 1. App Store Connect API Key 발급
1. https://appstoreconnect.apple.com/access/integrations/api
2. "Generate API Key" → role: **App Manager** (또는 Admin)
3. `.p8` 파일 다운로드, **Key ID** + **Issuer ID** 복사

### 2. GitHub Secrets 3개 추가
Repository → Settings → Secrets and variables → Actions → "Release" environment:

| Secret 이름 | 값 |
|---|---|
| `APP_STORE_CONNECT_KEY_ID` | 위에서 복사한 Key ID (예: `ABC123XYZ`) |
| `APP_STORE_CONNECT_ISSUER_ID` | 위에서 복사한 Issuer ID (UUID 형식) |
| `APP_STORE_CONNECT_API_KEY` | `.p8` 파일 내용 통째로 (`-----BEGIN PRIVATE KEY-----` ~ `-----END PRIVATE KEY-----`) 또는 base64 인코딩 |

### 3. 사전 검증 (이미 OK일 수도 있음)
- `IOS_CERTIFICATES_P12`가 **Apple Distribution** 인증서인지 (Apple Development면 새로 발급 필요)
- `IOS_PROVISIONING_PROFILE` / `_WIDGET` / `_INTENTS`가 **App Store distribution profile**인지 (Development면 재발급 필요)
- 모두 같은 Team ID `N5V8W52U3U` 소속인지

### 4. 재시도
머지 후 새 태그 push:
```bash
git tag -a v2.5.19 -m "Release v2.5.19 - iOS deploy fix"
git push origin v2.5.19
```
또는 v2.5.18 deploy를 GitHub Actions UI에서 re-run.

## Risk

- **Android deploy 영향: 없음** — Android job은 손대지 않음.
- **iOS deploy 위험도: 낮음** — fallback 로직으로 시크릿 없으면 기존 동작 그대로. 더 나빠질 일 없음.
- 시크릿 다 추가했는데도 실패하면 → 인증서/프로파일 자체 문제 (위 #3 검증 필요).

## Verified

- `python3 yaml.safe_load` → deploy.yml 문법 OK
- Fastfile 변경은 전부 ENV 가드 처리 — 시크릿 없을 때 안전하게 fallback
- 인앱 업데이트 코드(#242) 영향 없음 (Android-only 기능)
