### PR TITLE
fix(ci): tighten iOS release profile validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -462,6 +462,27 @@ jobs:
             echo "$uuid"
           }
 
+          validate_profile() {
+            local label="$1"
+            local name="$2"
+            local uuid="$3"
+            local expiration="$4"
+
+            if [ -z "$name" ] || [ -z "$uuid" ] || [ -z "$expiration" ]; then
+              echo "❌ ERROR: $label provisioning profile metadata is incomplete."
+              echo "       name=${name:-<missing>}, uuid=${uuid:-<missing>}, expiration=${expiration:-<missing>}"
+              exit 1
+            fi
+
+            expiration_epoch=$(ruby -rtime -e 'puts Time.parse(ARGV[0]).to_i' "$expiration")
+            now_epoch=$(date +%s)
+            if [ "$expiration_epoch" -le "$now_epoch" ]; then
+              echo "❌ ERROR: $label provisioning profile has expired: $name ($expiration)"
+              echo "       Refresh the corresponding IOS_PROVISIONING_PROFILE* GitHub secret in the Release environment."
+              exit 1
+            fi
+          }
+
           MAIN_PROFILE="$PP_DIR/profile.mobileprovision"
           WIDGET_PROFILE="$PP_DIR/profile_widget.mobileprovision"
           INTENTS_PROFILE="$PP_DIR/profile_intents.mobileprovision"
@@ -472,17 +493,18 @@ jobs:
           MAIN_UUID=$(install_by_uuid "$MAIN_PROFILE")
           WIDGET_UUID=$(install_by_uuid "$WIDGET_PROFILE")
           INTENTS_UUID=$(install_by_uuid "$INTENTS_PROFILE")
+          MAIN_EXPIRATION=$(extract_field "$MAIN_PROFILE" ExpirationDate)
+          WIDGET_EXPIRATION=$(extract_field "$WIDGET_PROFILE" ExpirationDate)
+          INTENTS_EXPIRATION=$(extract_field "$INTENTS_PROFILE" ExpirationDate)
 
           echo "📋 Extracted profile metadata:"
-          echo "  • Main:    ${MAIN_NAME:-<missing>} (${MAIN_UUID:-missing UUID})"
-          echo "  • Widget:  ${WIDGET_NAME:-<missing>} (${WIDGET_UUID:-missing UUID})"
-          echo "  • Intents: ${INTENTS_NAME:-<missing>} (${INTENTS_UUID:-missing UUID})"
+          echo "  • Main:    ${MAIN_NAME:-<missing>} (${MAIN_UUID:-missing UUID}) expires ${MAIN_EXPIRATION:-<missing>}"
+          echo "  • Widget:  ${WIDGET_NAME:-<missing>} (${WIDGET_UUID:-missing UUID}) expires ${WIDGET_EXPIRATION:-<missing>}"
+          echo "  • Intents: ${INTENTS_NAME:-<missing>} (${INTENTS_UUID:-missing UUID}) expires ${INTENTS_EXPIRATION:-<missing>}"
 
-          if [ -z "$MAIN_NAME" ] || [ -z "$WIDGET_NAME" ] || [ -z "$INTENTS_NAME" ] ||
-             [ -z "$MAIN_UUID" ] || [ -z "$WIDGET_UUID" ] || [ -z "$INTENTS_UUID" ]; then
-            echo "⚠️  At least one profile name or UUID is empty — Fastfile will fall back to legacy build_app config."
-            echo "    For App Store export this will likely fail. Verify all 3 IOS_PROVISIONING_PROFILE* secrets."
-          fi
+          validate_profile "Main" "$MAIN_NAME" "$MAIN_UUID" "$MAIN_EXPIRATION"
+          validate_profile "Widget" "$WIDGET_NAME" "$WIDGET_UUID" "$WIDGET_EXPIRATION"
+          validate_profile "Intents" "$INTENTS_NAME" "$INTENTS_UUID" "$INTENTS_EXPIRATION"
 
           {
             echo "IOS_PROFILE_NAME=$MAIN_NAME"

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -82,11 +82,6 @@ platform :ios do
         clean: true,
         export_method: "app-store",
         destination: "generic/platform=iOS",
-        xcargs: [
-          "DEVELOPMENT_TEAM=#{team_id}",
-          "CODE_SIGN_STYLE=Manual",
-          "CODE_SIGN_IDENTITY='Apple Distribution'",
-        ].join(" "),
         export_options: {
           method: "app-store",
           signingStyle: "manual",


### PR DESCRIPTION
## Why

`v2.5.19` deploy got further than the previous releases: Android uploaded to Google Play Alpha successfully, and iOS now passes certificate/profile import plus explicit profile mapping. The iOS job then failed during archive with two clearer issues:

- the global `xcargs` applied manual signing to Pods as well, causing Pods targets to look for distribution signing certificates;
- the main `IOS_PROVISIONING_PROFILE` secret is expired (`iOS Team Store Provisioning Profile: org.sparcs.otlplus`, expired 2026-05-19), so the next iOS deploy needs refreshed Release environment credentials.

## What changed

- Remove global `xcargs` from `build_app`; Runner targets are already configured via `update_code_signing_settings` and `update_project_provisioning`, so Pods should not inherit manual distribution signing.
- Validate iOS provisioning profile metadata before archive:
  - require name, UUID, and expiration date for main/widget/intents profiles;
  - fail early if any profile is expired, with the exact secret family to refresh.

## Verified

- `python3` YAML parse for `.github/workflows/deploy.yml`
- `bash -n` for every workflow `run:` step
- `ruby -c ios/fastlane/Fastfile`
- `git diff --check`

## Remaining external gate

The repository Release environment needs a refreshed `IOS_PROVISIONING_PROFILE` secret for `org.sparcs.otlplus`; the current one expired on 2026-05-19. After refreshing it, rerun the iOS deploy / push a follow-up release tag.