### PR TITLE
fix(ci): allow manual platform-specific store deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Store deployment target"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - android
+          - ios
 
 env:
   FLUTTER_VERSION: "3.32.x"
@@ -13,6 +24,7 @@ env:
 jobs:
   
   deploy-android:
+    if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'android' }}
     environment: Release
     name: Deploy Android to Google Play
     runs-on: ubuntu-latest
@@ -220,6 +232,7 @@ jobs:
           rm -f android/key.properties
 
   deploy-ios:
+    if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'ios' }}
     environment: Release
     name: Deploy iOS to TestFlight
     runs-on: macos-15


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to the store deploy workflow.
- Allow manual deploy target selection: `all`, `android`, or `ios`.
- Keep tag pushes deploying both store jobs as before.

## Why
The `v2.5.19` release uploaded Android to Google Play Alpha successfully, but iOS is blocked by the expired Release environment `IOS_PROVISIONING_PROFILE` for `org.sparcs.otlplus`. After that secret is refreshed, maintainers need an iOS-only retry path from `main` so Android is not uploaded again just to recover the iOS TestFlight deploy.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml"); puts "yaml ok"'`\n- `ruby -ryaml -e 'doc=YAML.load_file(".github/workflows/deploy.yml"); jobs=doc.fetch("jobs"); jobs.each do |job_name, job| Array(job["steps"]).each_with_index do |step, idx| next unless step["run"]; file="/tmp/#{job_name}-#{idx}.sh"; File.write(file, step["run"]); system("bash", "-n", file) or abort("bash -n failed: #{job_name} step #{idx}"); end; end; puts "run blocks ok"'`\n- `git diff --check`