### PR TITLE
fix(ci): support iOS-only release retry tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,11 @@ env:
 jobs:
   
   deploy-android:
-    if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'android' }}
+    if: >-
+      ${{
+        (github.event_name == 'push' && !contains(github.ref_name, '-ios-only')) ||
+        (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && (inputs.platform == 'all' || inputs.platform == 'android'))
+      }}
     environment: Release
     name: Deploy Android to Google Play
     runs-on: ubuntu-latest
@@ -232,7 +236,11 @@ jobs:
           rm -f android/key.properties
 
   deploy-ios:
-    if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'ios' }}
+    if: >-
+      ${{
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && (inputs.platform == 'all' || inputs.platform == 'ios'))
+      }}
     environment: Release
     name: Deploy iOS to TestFlight
     runs-on: macos-15

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,8 @@ FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=****-****-****-****
 
 - Android: Google Play 스토어 `비공개 테스트 - Alpha` 트랙으로 업로드
 - iOS: TestFlight로 업로드
+- 일반 `v*` 태그는 Android와 iOS를 모두 배포합니다.
+- Android가 이미 업로드된 뒤 iOS만 재시도해야 한다면 `v2.5.19-ios-only.1`처럼 `-ios-only`가 포함된 `v*` 태그를 사용합니다.
 
 ```bash
 cd android && bundle exec fastlane alpha && cd ../ios && bundle exec fastlane alpha


### PR DESCRIPTION
## Summary
- Skip the Android deploy job for `v*` tags that contain `-ios-only`.
- Restrict manual workflow dispatch deploy jobs to tag refs so they respect the Release environment `v*` policy.
- Document the iOS-only retry tag convention in `CONTRIBUTING.md`.

## Why
The Release environment only allows `v*` tag deployments. A manual dispatch from `main` is rejected before any iOS steps run, so the recovery path after Android has already uploaded needs to be tag-based while still skipping Android.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml"); puts "yaml ok"'`\n- `ruby -ryaml -e 'doc=YAML.load_file(".github/workflows/deploy.yml"); jobs=doc.fetch("jobs"); jobs.each do |job_name, job| Array(job["steps"]).each_with_index do |step, idx| next unless step["run"]; file="/tmp/#{job_name}-#{idx}.sh"; File.write(file, step["run"]); system("bash", "-n", file) or abort("bash -n failed: #{job_name} step #{idx}"); end; end; puts "run blocks ok"'`\n- `git diff --check`