### PR TITLE
Use the Release environment for store workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
       ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
       ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -212,7 +212,7 @@ jobs:
         uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
-          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          doppler-token: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
           inject-env-vars: true
 
       - name: Map release configuration
@@ -295,7 +295,7 @@ jobs:
       APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
       APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -582,7 +582,7 @@ jobs:
         uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
-          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          doppler-token: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
           inject-env-vars: true
 
       - name: Map release configuration

--- a/.github/workflows/firebase-distribution.yml
+++ b/.github/workflows/firebase-distribution.yml
@@ -34,6 +34,7 @@ jobs:
       }}
     name: Distribute Android via Firebase
     runs-on: ubuntu-latest
+    environment: Release
     env:
       ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE }}
       ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -41,7 +42,7 @@ jobs:
       ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
       FIREBASE_APP_ID_ANDROID: ${{ secrets.FIREBASE_APP_ID_ANDROID }}
       FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -82,7 +83,7 @@ jobs:
         uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
-          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          doppler-token: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
           inject-env-vars: true
 
       - name: Map release configuration
@@ -157,7 +158,7 @@ jobs:
       IOS_PROVISIONING_PROFILE_INTENTS: ${{ secrets.IOS_PROVISIONING_PROFILE_INTENTS }}
       FIREBASE_APP_ID_IOS: ${{ secrets.FIREBASE_APP_ID_IOS }}
       FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -178,7 +179,7 @@ jobs:
         uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
-          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          doppler-token: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
           inject-env-vars: true
 
       - name: Map release configuration

--- a/.github/workflows/store-status.yml
+++ b/.github/workflows/store-status.yml
@@ -19,17 +19,17 @@ jobs:
   android:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.platform == 'android' || inputs.platform == 'both' }}
     runs-on: ubuntu-latest
-    environment: store-review
+    environment: Release
     env:
       GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Load release secrets
         uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
-          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          doppler-token: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
           inject-env-vars: true
       - name: Map release configuration
         run: echo "POSTHOG_HOST=${POSTHOG_HOST:-https://us.i.posthog.com}" >> "$GITHUB_ENV"
@@ -69,20 +69,20 @@ jobs:
   ios:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.platform == 'ios' || inputs.platform == 'both' }}
     runs-on: macos-15
-    environment: store-review
+    environment: Release
     env:
       APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
       APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
       APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
       APP_IDENTIFIER: org.sparcs.otlplus
-      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Load release secrets
         uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
-          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          doppler-token: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
           inject-env-vars: true
       - name: Map release configuration
         run: echo "POSTHOG_HOST=${POSTHOG_HOST:-https://us.i.posthog.com}" >> "$GITHUB_ENV"

--- a/.github/workflows/submit-store-review.yml
+++ b/.github/workflows/submit-store-review.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   submit-android:
     if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (inputs.platform == 'all' || inputs.platform == 'android')) }}
-    environment: store-review
+    environment: Release
     name: Submit Android for Google Play review
     runs-on: ubuntu-latest
     env:
@@ -33,7 +33,7 @@ jobs:
       ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
       ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
         uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
-          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          doppler-token: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
           inject-env-vars: true
 
       - name: Map release configuration
@@ -155,7 +155,7 @@ jobs:
 
   submit-ios:
     if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (inputs.platform == 'all' || inputs.platform == 'ios')) }}
-    environment: store-review
+    environment: Release
     name: Submit iOS for App Store review
     runs-on: macos-15
     env:
@@ -171,7 +171,7 @@ jobs:
       APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
       APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -277,7 +277,7 @@ jobs:
         uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
-          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          doppler-token: ${{ secrets.DOPPLER_TOKEN || secrets.DOPPER_TOKEN }}
           inject-env-vars: true
 
       - name: Map release configuration


### PR DESCRIPTION
## Summary
Follow-up to #249, fixing configuration mismatches found while verifying the deployment setup against the live repository settings.

- Point `submit-store-review.yml` and `store-status.yml` at the existing **`Release`** environment instead of a separate `store-review` one. `Release` already holds the signing keys, provisioning profiles, and `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, so the extra environment was redundant and had no secrets attached. The now-unused `store-review` environment has been deleted.
- Add the missing `environment: Release` to the Firebase **Android** distribution job, which previously could not reach the environment-scoped signing secrets.
- Accept either `DOPPLER_TOKEN` or `DOPPER_TOKEN` for the Doppler service token. The repository secret is currently registered as `DOPPER_TOKEN` (missing an `L`), which would fail every deployment; the fallback keeps releases working today and stays correct once the secret is renamed.

## Validation
YAML parses for all workflows. No application code is touched, so the existing build/test gates cover the change.

## Follow-up
Renaming the secret to `DOPPLER_TOKEN` and dropping the fallback is recommended, but not required for releases to run.
