### PR TITLE
Use the default token for release drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release Drafter
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
 
 jobs:
   update-release-draft:
@@ -11,4 +16,4 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.TAG_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- replace the former maintainer-owned `TAG_PAT` with the ephemeral repository `github.token`
- grant Release Drafter only `contents: write` and `pull-requests: read`
- add manual draft refresh without pushing directly to protected `main`

## Root cause
- commit `4224412` intentionally switched Release Drafter to `TAG_PAT`, so drafts/releases were attributed to that PAT owner
- active `main` protection requires a PR approval and required checks, but no ruleset blocks tag or release creation
- the latest `v2.5.20` store deployment failure was caused by an expired iOS provisioning profile, not branch protection

## Verification
- YAML parse passed
- Release Drafter v5 token/permission contract checked
- five review lanes covered goal, workflow QA, code quality, security, and release-history context

## Post-merge migration
- the existing draft `v2.5.12` keeps author `sboh1214`; GitHub cannot rewrite a release author
- back up and delete that draft after merge, manually run Release Drafter to recreate it as `github-actions[bot]`, and set its tag/name to the actual next version before publishing
- revoke the old PAT and remove the unused `TAG_PAT` repository secret after confirming the new draft